### PR TITLE
プロフィールページの完成

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/AuthController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/AuthController.java
@@ -22,4 +22,27 @@ public class AuthController {
     model.addAttribute("roles", userDetails.getRoleName());
     return "home";
   }
+
+  @GetMapping("/profile")
+  public String profile(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    model.addAttribute("username", userDetails.getUsername());
+    model.addAttribute("fullName", userDetails.getFullName());
+    model.addAttribute("role", userDetails.getRoleName());
+    model.addAttribute("company", userDetails.getCompanyName());
+    model.addAttribute("department", userDetails.getDepartmentName());
+    return "/profile";
+  }
+
+  @GetMapping("/profile/edit")
+  public String profile_edit(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    model.addAttribute("fullName", userDetails.getFullName());
+    model.addAttribute("password", userDetails.getPassword());
+    return "/profile-edit";
+  }
+
+  @GetMapping("/profile/edit/done")
+  public String profile_edit_done(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    model.addAttribute("fullName", userDetails.getFullName());
+    return "/profile-edit-done";
+  }
 }

--- a/src/main/java/com/example/sharing_service_site/controller/ProfileController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/ProfileController.java
@@ -1,0 +1,58 @@
+package com.example.sharing_service_site.controller;
+
+import com.example.sharing_service_site.service.CustomUserDetails;
+import com.example.sharing_service_site.service.CustomUserDetailsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+public class ProfileController {
+
+  @Autowired
+  private BCryptPasswordEncoder passwordEncoder;
+
+  @Autowired
+  private CustomUserDetailsService userDetailsService;
+
+  @PostMapping("/profile/password-edit")
+  public String changePassword(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @RequestParam String oldPassword,
+        @RequestParam String newPassword,
+        @RequestParam String confirmPassword,
+        Model model) {
+
+    boolean hasError = false;
+
+    if (newPassword.length() < 8) {
+      model.addAttribute("newPasswordError", "パスワードは8文字以上にしてください。");
+      model.addAttribute("oldPassword", oldPassword);
+      hasError = true;
+    }
+
+    if (!newPassword.equals(confirmPassword)) {
+      model.addAttribute("confirmPasswordError", "新しいパスワードが一致しません。");
+      model.addAttribute("oldPassword", oldPassword);
+      hasError = true;
+    }
+
+    if (!passwordEncoder.matches(oldPassword, userDetails.getPassword())) {
+      model.addAttribute("oldPasswordError", "旧パスワードが間違っています。");
+      hasError = true;
+    }
+
+    if (hasError) {
+      model.addAttribute("fullName", userDetails.getFullName());
+      return "/profile-edit";
+    }
+
+    String encodedPassword = passwordEncoder.encode(newPassword);
+    userDetailsService.updatePassword(userDetails.getUsername(), encodedPassword);
+
+    return "redirect:/profile/edit/done";
+  }
+}

--- a/src/main/java/com/example/sharing_service_site/entity/Role.java
+++ b/src/main/java/com/example/sharing_service_site/entity/Role.java
@@ -19,7 +19,7 @@ public class Role {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long roleId;
 
-  private String roleName; // リストで扱うため現在は実装無し
+  private String roleName;
 
   @OneToMany(mappedBy = "roles")
   private List<User> users;

--- a/src/main/java/com/example/sharing_service_site/entity/User.java
+++ b/src/main/java/com/example/sharing_service_site/entity/User.java
@@ -61,14 +61,14 @@ public class User {
   public String getEmployeeNumber() { return employeeNumber; }
   public String getPassword() { return password; }
   public String getFullName() { return fullName; }
-  public Set<Role> getRoles() { return roles; } // リストで扱う
+  public Set<Role> getRoles() { return roles; }
   public Company getCompany() { return company; }
   public Department getDepartment() { return department; }
 
   public void setEmployeeNumber(String employeeNumber) { this.employeeNumber = employeeNumber; }
   public void setPassword(String password) { this.password = password; }
   public void setFullName(String fullName) { this.fullName = fullName; }
-  public void setRoles(Set<Role> roles) { this.roles = roles; } // リストで扱う
+  public void setRoles(Set<Role> roles) { this.roles = roles; }
   public void setCompany(Company company) { this.company = company; }
   public void setDepartment(Department department) { this.department = department; }
 }

--- a/src/main/java/com/example/sharing_service_site/infrastructure/WebSecurityConfig.java
+++ b/src/main/java/com/example/sharing_service_site/infrastructure/WebSecurityConfig.java
@@ -16,7 +16,7 @@ public class WebSecurityConfig {
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.authorizeHttpRequests(auth -> auth
       .requestMatchers("/login", "/css/**", "/images/**").permitAll()
-      // .requestMatchers("/home").hasRole("USER") // USERロールの定義不備
+      // .requestMatchers("/home").hasRole("USER") // 制限ページの設定不足
       .anyRequest().authenticated())
     .formLogin(login -> login
       .loginPage("/login")

--- a/src/main/java/com/example/sharing_service_site/service/CustomUserDetailsService.java
+++ b/src/main/java/com/example/sharing_service_site/service/CustomUserDetailsService.java
@@ -29,4 +29,12 @@ public class CustomUserDetailsService implements UserDetailsService {
         user.getCompany(),
         user.getDepartment());
   }
+
+  public void updatePassword(String employeeNumber, String encodedPassword) {
+    com.example.sharing_service_site.entity.User user = userRepository.findByEmployeeNumber(employeeNumber)
+        .orElseThrow(() -> new UsernameNotFoundException("社員番号が存在しません: " + employeeNumber));
+
+    user.setPassword(encodedPassword);
+    userRepository.save(user);
+  }
 }

--- a/src/main/resources/static/css/profile.css
+++ b/src/main/resources/static/css/profile.css
@@ -1,0 +1,87 @@
+.main-content h1 {
+  flex: 1;
+  padding-left: 1rem;
+  border-radius: 8px;
+}
+
+.main-content h2 {
+  text-align: center;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #004aad;
+  background-color: #f0f8ff;
+  padding: 1rem;
+  border-radius: 8px;
+  margin: 1.5rem auto;
+  max-width: 500px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.profile-card {
+  background-color: white;
+  border-radius: 8px;
+  padding: 2rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.profile-item {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.profile-item:last-child {
+  border-bottom: none;
+}
+
+.profile-label {
+  font-weight: 600;
+  color: #555;
+}
+
+.value {
+  color: #111;
+}
+
+.profile-container h1 {
+  margin-bottom: 1.5rem;
+  font-size: 2rem;
+  color: #111;
+}
+
+.profile-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin: 1rem;
+}
+
+.profile-button {
+  background-color: #004aad;
+  color: white;
+  padding: 0.6rem 1.2rem;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: bold;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+}
+
+.profile-button:hover {
+  background-color: #0066ff;
+  transform: translateY(-2px);
+}
+
+.profile-button:active {
+  transform: translateY(0);
+}
+
+.field-error {
+  color: red;
+  font-size: 0.9em;
+  margin-top: 4px;
+  display: block;
+  text-align: right;
+}

--- a/src/main/resources/static/css/sidebar.css
+++ b/src/main/resources/static/css/sidebar.css
@@ -64,7 +64,7 @@
 
 .main-content {
   flex: 1;
-  padding: 1rem;
+  padding-left: 1rem;
   margin-left: 60px;
   margin-top: 60px;
   transition: margin-left 0.3s ease;

--- a/src/main/resources/templates/profile-edit-done.html
+++ b/src/main/resources/templates/profile-edit-done.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Sharing Service Site</title>
+    <link rel="stylesheet" th:href="@{/css/profile.css}" />
+    <link rel="stylesheet" th:href="@{/css/header.css}" />
+    <link rel="stylesheet" th:href="@{/css/sidebar.css}" />
+  </head>
+  <body>
+    <div th:replace="fragments/header :: header(${fullName})"></div>
+
+    <div class="layout">
+      <div th:replace="fragments/sidebar :: sidebar"></div>
+
+      <div class="main-content">
+        <h1>パスワードの変更</h1>
+
+        <h2>パスワードの変更が完了しました。</h2>
+
+        <div class="profile-actions">
+          <a class="profile-button" th:href="@{/profile}">
+            プロフィールページに戻る
+          </a>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/templates/profile-edit.html
+++ b/src/main/resources/templates/profile-edit.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Sharing Service Site</title>
+    <link rel="stylesheet" th:href="@{/css/profile.css}" />
+    <link rel="stylesheet" th:href="@{/css/header.css}" />
+    <link rel="stylesheet" th:href="@{/css/sidebar.css}" />
+  </head>
+  <body>
+    <div th:replace="fragments/header :: header(${fullName})"></div>
+
+    <div class="layout">
+      <div th:replace="fragments/sidebar :: sidebar"></div>
+
+      <div class="main-content">
+        <h1>パスワードの変更</h1>
+
+        <form
+          th:action="@{/profile/password-edit}"
+          method="post"
+          class="profile-card"
+        >
+          <div class="profile-item">
+            <label class="profile-label" for="oldPassword">旧パスワード</label>
+            <input
+              type="password"
+              id="oldPassword"
+              name="oldPassword"
+              th:value="${oldPassword}"
+              autocomplete="current-password"
+              required
+            />
+          </div>
+          <span
+            th:if="${oldPasswordError}"
+            th:text="${oldPasswordError}"
+            class="field-error"
+          ></span>
+
+          <div class="profile-item">
+            <label class="profile-label" for="newPassword">新パスワード</label>
+            <input
+              type="password"
+              id="newPassword"
+              name="newPassword"
+              th:value="${newPassword}"
+              autocomplete="new-password"
+              required
+            />
+          </div>
+          <span
+            class="field-error"
+            th:if="${newPasswordError}"
+            th:text="${newPasswordError}"
+          ></span>
+
+          <div class="profile-item">
+            <label class="profile-label" for="confirmPassword"
+              >新パスワード(確認)</label
+            >
+            <input
+              type="password"
+              id="confirmPassword"
+              name="confirmPassword"
+              th:value="${confirmPassword}"
+              autocomplete="confirm-password"
+              required
+            />
+          </div>
+          <span
+            th:if="${confirmPasswordError}"
+            th:text="${confirmPasswordError}"
+            class="field-error"
+          ></span>
+
+          <div class="profile-actions">
+            <button type="submit" class="profile-button">確定</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Sharing Service Site</title>
+    <link rel="stylesheet" th:href="@{/css/profile.css}" />
+    <link rel="stylesheet" th:href="@{/css/header.css}" />
+    <link rel="stylesheet" th:href="@{/css/sidebar.css}" />
+  </head>
+  <body>
+    <div th:replace="fragments/header :: header(${fullName})"></div>
+
+    <div class="layout">
+      <div th:replace="fragments/sidebar :: sidebar"></div>
+
+      <div class="main-content">
+        <h1>プロフィール</h1>
+
+        <div class="profile-card">
+          <div class="profile-item">
+            <span class="profile-label">従業員番号</span>
+            <span class="value" th:text="${username}">従業員番号</span>
+          </div>
+
+          <div class="profile-item">
+            <span class="profile-label">氏名</span>
+            <span class="value" th:text="${fullName}">氏名</span>
+          </div>
+
+          <div class="profile-item">
+            <span class="profile-label">会社</span>
+            <span class="value" th:text="${company}">会社</span>
+          </div>
+
+          <div class="profile-item">
+            <span class="profile-label">部署</span>
+            <span class="value" th:text="${department}">部署</span>
+          </div>
+
+          <div class="profile-item">
+            <span class="profile-label">ロール</span>
+            <span class="value" th:text="${role}">ロール</span>
+          </div>
+
+          <div class="profile-actions">
+            <a class="profile-button" th:href="@{/profile/edit}">
+              パスワードの変更
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
# 概要
プロフィールページの作成とパスワードの再設定機能実装

# 範囲
## やったこと
* ログインしたユーザーの情報を確認することができるページの追加
* パスワードの変更(8文字以上で再確認あり)

## やっていないこと
* より厳密なパスワードの条件設定(半角英数字など)
* パスワード以外の情報の編集

# 動作確認
サイドメニューのプロフィールから表示してパスワードの変更まで確認
不正確な旧パスワードや新パスワードの入力によるメッセージの表示

Issue: #9 
