### PR TITLE
オーバーレイの作成

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/ProfileController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/ProfileController.java
@@ -18,7 +18,7 @@ public class ProfileController {
   @Autowired
   private CustomUserDetailsService userDetailsService;
 
-  @PostMapping("/profile/password-edit")
+  @PostMapping("/profile/edit")
   public String changePassword(
         @AuthenticationPrincipal CustomUserDetails userDetails,
         @RequestParam String oldPassword,
@@ -42,6 +42,7 @@ public class ProfileController {
 
     if (!passwordEncoder.matches(oldPassword, userDetails.getPassword())) {
       model.addAttribute("oldPasswordError", "旧パスワードが間違っています。");
+      model.asMap().remove("oldPassword");
       hasError = true;
     }
 

--- a/src/main/resources/static/css/profile.css
+++ b/src/main/resources/static/css/profile.css
@@ -20,11 +20,11 @@
 .profile-card {
   background-color: white;
   border-radius: 8px;
-  padding: 2rem;
+  padding: 1rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .profile-item {
@@ -63,6 +63,7 @@
   background-color: #004aad;
   color: white;
   padding: 0.6rem 1.2rem;
+  border: none;
   border-radius: 6px;
   text-decoration: none;
   font-weight: bold;

--- a/src/main/resources/static/css/sidebar.css
+++ b/src/main/resources/static/css/sidebar.css
@@ -13,6 +13,7 @@
   overflow-x: hidden;
   height: 100vh;
   align-self: stretch;
+  z-index: 15;
 }
 
 .sidebar.expanded {
@@ -65,13 +66,30 @@
 .main-content {
   flex: 1;
   padding-left: 1rem;
-  margin-left: 60px;
-  margin-top: 60px;
+  margin: 60px;
   transition: margin-left 0.3s ease;
+  z-index: 5;
+  position: relative;
 }
 
 .sidebar:not(.expanded) a {
   pointer-events: none;
   cursor: default;
   opacity: 0.6;
+}
+
+.overlay {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease;
+  z-index: 10;
+}
+
+.overlay.active {
+  opacity: 1;
+  visibility: visible;
 }

--- a/src/main/resources/static/js/sidebar.js
+++ b/src/main/resources/static/js/sidebar.js
@@ -1,0 +1,31 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const sidebar = document.getElementById("sidebar");
+  const overlay = document.querySelector(".overlay");
+  const mainContent = document.querySelector(".main-content");
+  const toggleBtn = document.getElementById("menuToggle");
+
+  if (!sidebar || !overlay || !toggleBtn) return;
+
+  function openSidebar() {
+    sidebar.classList.add("expanded");
+    overlay.classList.add("active");
+    mainContent.classList.add("shifted");
+  }
+
+  function closeSidebar() {
+    sidebar.classList.remove("expanded");
+    overlay.classList.remove("active");
+    mainContent.classList.remove("shifted");
+  }
+
+  toggleBtn.addEventListener("click", () => {
+    const isOpen = sidebar.classList.contains("expanded");
+    if (isOpen) {
+      closeSidebar();
+    } else {
+      openSidebar();
+    }
+  });
+
+  overlay.addEventListener("click", closeSidebar);
+});

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -1,6 +1,8 @@
 <div th:fragment="sidebar">
   <nav class="sidebar" id="sidebar">
-    <button class="toggle-btn" onclick="toggleSidebar()">☰</button>
+    <button class="toggle-btn" id="menuToggle" onclick="toggleSidebar()">
+      ☰
+    </button>
     <ul>
       <li>
         <a th:href="@{/home}" title="ホーム"
@@ -20,9 +22,5 @@
     </ul>
   </nav>
 
-  <script>
-    function toggleSidebar() {
-      document.getElementById("sidebar").classList.toggle("expanded");
-    }
-  </script>
+  <div class="overlay"></div>
 </div>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -22,5 +22,7 @@
         <p><span th:text="${roles}">ロール</span></p>
       </div>
     </div>
+
+    <script th:src="@{/js/sidebar.js}"></script>
   </body>
 </html>

--- a/src/main/resources/templates/profile-edit-done.html
+++ b/src/main/resources/templates/profile-edit-done.html
@@ -25,5 +25,7 @@
         </div>
       </div>
     </div>
+    
+    <script th:src="@{/js/sidebar.js}"></script>
   </body>
 </html>

--- a/src/main/resources/templates/profile-edit.html
+++ b/src/main/resources/templates/profile-edit.html
@@ -17,7 +17,7 @@
         <h1>パスワードの変更</h1>
 
         <form
-          th:action="@{/profile/password-edit}"
+          th:action="@{/profile/edit}"
           method="post"
           class="profile-card"
         >
@@ -80,5 +80,7 @@
         </form>
       </div>
     </div>
+
+    <script th:src="@{/js/sidebar.js}"></script>
   </body>
 </html>

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -50,5 +50,7 @@
         </div>
       </div>
     </div>
+
+    <script th:src="@{/js/sidebar.js}"></script>
   </body>
 </html>


### PR DESCRIPTION
# 概要
サイドメニューを開いているときにメインコンテンツを反応しないようにするためのオーバーレイを作成する

# 範囲
## やったこと
* サイドバーを開くとサイドバー以外の要素を暗くし、操作できないようにする
* オーバーレイが表示されている時、サイドバー以外をクリックするとオーバーレイが消えてサイドバーが閉じる
* パスワード編集ページのリンクの不具合やボタンの軽微な修正

## やっていないこと
* ヘッダーのオーバーレイ解除(ヘッダーはオーバーレイしなくてもよいかもしれない)

# 動作確認
サイドバーをクリックし、それぞれの要素をクリックする

Issue: #11 