### PR TITLE
部署選択画面の完成

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/AuthController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/AuthController.java
@@ -1,14 +1,27 @@
 package com.example.sharing_service_site.controller;
 
+import java.util.List;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
 
+import com.example.sharing_service_site.entity.Department;
 import com.example.sharing_service_site.service.CustomUserDetails;
+import com.example.sharing_service_site.service.DepartmentService;
 
 @Controller
 public class AuthController {
+
+  private final DepartmentService departmentService;
+
+  public AuthController(DepartmentService departmentService) {
+    this.departmentService = departmentService;
+  }
+
   @GetMapping("/login")
   public String login() {
     return "/login";
@@ -17,10 +30,20 @@ public class AuthController {
   @GetMapping("/home")
   public String home(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
     model.addAttribute("fullName", userDetails.getFullName());
-    model.addAttribute("company", userDetails.getCompanyName());
-    model.addAttribute("department", userDetails.getDepartmentName());
-    model.addAttribute("roles", userDetails.getRoleName());
+    model.addAttribute("companyName", userDetails.getCompanyName());
+    model.addAttribute("company", userDetails.getCompany());
+    model.addAttribute("department", userDetails.getDepartment());
+
+    List<Department> rootDepartments =
+      departmentService.getRootDepartmentsByCompany(userDetails.getCompany());
+    model.addAttribute("departments", rootDepartments);
     return "home";
+  }
+
+  @GetMapping("/departments/{id}")
+  @ResponseBody
+  public List<Department> getChildDepartments(@PathVariable Long id) {
+    return departmentService.getChildDepartments(id);
   }
 
   @GetMapping("/profile")

--- a/src/main/java/com/example/sharing_service_site/controller/DepartmentController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/DepartmentController.java
@@ -1,0 +1,25 @@
+package com.example.sharing_service_site.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.sharing_service_site.entity.Department;
+import com.example.sharing_service_site.repository.DepartmentRepository;
+
+@RestController
+@RequestMapping("/departments")
+public class DepartmentController {
+
+  private DepartmentRepository departmentRepository;
+
+  @GetMapping("/departments/{parentId}/children")
+  @ResponseBody
+  public List<Department> getChildDepartments(@PathVariable Long parentId) {
+    return departmentRepository.findByParentDepartmentId(parentId);
+  }
+}

--- a/src/main/java/com/example/sharing_service_site/entity/Department.java
+++ b/src/main/java/com/example/sharing_service_site/entity/Department.java
@@ -37,5 +37,7 @@ public class Department {
   @OneToMany(mappedBy = "department")
   private List<User> users;
 
+  public Long getDepartmentId() { return departmentId; }
   public String getDepartmentName() { return departmentName; }
+  public Department getParent() { return parent; }
 }

--- a/src/main/java/com/example/sharing_service_site/repository/CompanyRepository.java
+++ b/src/main/java/com/example/sharing_service_site/repository/CompanyRepository.java
@@ -1,0 +1,22 @@
+package com.example.sharing_service_site.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.sharing_service_site.entity.Company;
+
+/**
+ * 会社情報のDB操作を行う
+ */
+public interface CompanyRepository extends JpaRepository<Company, Long> {
+
+  /**
+   * 会社名を基に会社情報を検索する
+   * 会社名は一意であることを前提とする
+   * 
+   * @param companyName 検索対象の会社名
+   * @return 該当する会社情報
+   */
+  Optional<Company> findByCompanyName(String companyName);
+}

--- a/src/main/java/com/example/sharing_service_site/repository/DepartmentRepository.java
+++ b/src/main/java/com/example/sharing_service_site/repository/DepartmentRepository.java
@@ -1,0 +1,38 @@
+package com.example.sharing_service_site.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.sharing_service_site.entity.Company;
+import com.example.sharing_service_site.entity.Department;
+
+/**
+ * 部署情報のDB操作を行う
+ */
+public interface DepartmentRepository extends JpaRepository<Department, Long> {
+
+  /**
+   * 会社を基に部署情報を検索する
+   * 部署名は一意であることを前提とする
+   * 
+   * @param company 検索対象の会社
+   * @return 該当する部署情報
+   */
+  List<Department> findByCompany(Company company);
+
+  /**
+   * 親を基に部署情報を検索する
+   * 
+   * @param parent 検索対象の親
+   * @return 該当する部署情報
+   */
+  List<Department> findByParent(Department parent);
+
+  /**
+   * 親のIDを基に部署情報を検索する
+   * @param parentId 検索対象の親ID
+   * @return 該当する部署情報
+   */
+  List<Department> findByParentDepartmentId(Long parentId);
+}

--- a/src/main/java/com/example/sharing_service_site/service/DepartmentService.java
+++ b/src/main/java/com/example/sharing_service_site/service/DepartmentService.java
@@ -1,0 +1,40 @@
+package com.example.sharing_service_site.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.example.sharing_service_site.entity.Company;
+import com.example.sharing_service_site.entity.Department;
+import com.example.sharing_service_site.repository.DepartmentRepository;
+
+@Service
+public class DepartmentService {
+
+  @Autowired
+  private DepartmentRepository departmentRepository;
+
+  /**
+   * 会社名を指定して、ルート部署（親がnullの部署）を取得する
+   */
+  public List<Department> getRootDepartmentsByCompany(Company company) {
+    List<Department> allDepartments = departmentRepository.findByCompany(company);
+    // 親がnullの部署のみ返す
+    return allDepartments.stream()
+        .filter(d -> d.getParent() == null)
+        .toList();
+  }
+
+  /**
+   * 部署IDを指定して、その子部署一覧を取得する
+   */
+  public List<Department> getChildDepartments(Long parentDepartmentId) {
+    Optional<Department> parentOpt = departmentRepository.findById(parentDepartmentId);
+    if (parentOpt.isEmpty()) {
+      throw new IllegalArgumentException("部署が見つかりません: id=" + parentDepartmentId);
+    }
+    return departmentRepository.findByParent(parentOpt.get());
+  }
+}

--- a/src/main/resources/static/css/home.css
+++ b/src/main/resources/static/css/home.css
@@ -1,8 +1,40 @@
-body {
-  font-family: Arial, sans-serif;
-  margin: 40px;
+.department-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
 }
 
-h1 {
-  color: #2c3e50;
+.department-card {
+  background: #f0f8ff;
+  padding: 1rem;
+  text-align: center;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.department-card:hover {
+  background: #dbeeff;
+}
+
+.department-container {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.department-card {
+  background-color: #f0f8ff;
+  border-radius: 8px;
+  padding: 2rem;
+  text-align: center;
+  font-weight: bold;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  transition: background-color 0.2s ease;
+}
+
+.department-card:hover {
+  background-color: #e0f0ff;
 }

--- a/src/main/resources/static/js/home.js
+++ b/src/main/resources/static/js/home.js
@@ -1,0 +1,28 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const container = document.getElementById("departmentContainer");
+  const title = document.getElementById("companyTitle");
+  if (!container || !title) return;
+
+  container.addEventListener("click", async (event) => {
+    const card = event.target.closest(".department-card");
+    if (!card) return;
+
+    const departmentId = card.dataset.id;
+    const departmentName = card.textContent;
+
+    title.textContent = departmentName;
+
+    const response = await fetch(`/departments/${departmentId}`);
+    const childDepartments = await response.json();
+
+    container.innerHTML = "";
+
+    childDepartments.forEach((dept) => {
+      const div = document.createElement("div");
+      div.className = "department-card";
+      div.dataset.id = dept.departmentId;
+      div.textContent = dept.departmentName;
+      container.appendChild(div);
+    });
+  });
+});

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -14,15 +14,22 @@
       <div th:replace="fragments/sidebar :: sidebar"></div>
 
       <div class="main-content">
-        <h1>ようこそ、<span th:text="${fullName}">ユーザー名</span> さん！</h1>
-        <p>
-          所属：<span th:text="${company}">会社</span>・
-          <span th:text="${department}">部署</span>
-        </p>
-        <p><span th:text="${roles}">ロール</span></p>
+        <h1 class="company-title" id="companyTitle" th:text="${companyName}">
+          会社名
+        </h1>
+
+        <div id="departmentContainer" class="department-container">
+          <div
+            th:each="dept : ${departments}"
+            class="department-card"
+            th:data-id="${dept.departmentId}"
+            th:text="${dept.departmentName}"
+          ></div>
+        </div>
       </div>
     </div>
 
+    <script th:src="@{/js/home.js}"></script>
     <script th:src="@{/js/sidebar.js}"></script>
   </body>
 </html>


### PR DESCRIPTION
# 概要
メインコンテンツである部署選択を可能にした

# 範囲
## やったこと
* ホーム画面に会社名のタイトルと部を一覧表示した
* 部を選択するとその部がタイトルとなり、子要素の部署が一覧表示される
* 選択を続けるとその部署のタイトルのみになる

## やっていないこと
* 部署選択後の詳細な機能やパンくずリストの作成
* 新しい部署の作成
* 権限による認可処理

# 動作確認
部署を選択するとDBに保存された部署が表示される

Issue: #15 