### PR TITLE
設定ページの完成

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/AuthController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/AuthController.java
@@ -144,4 +144,31 @@ public class AuthController {
     model.addAttribute("fullName", userDetails.getFullName());
     return "/profile-edit-done";
   }
+
+  @GetMapping("/settings")
+  public String settings(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    model.addAttribute("fullName", userDetails.getFullName());
+    return "/settings";
+  }
+
+  @GetMapping("/settings/user")
+  public String settingsUser(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    model.addAttribute("fullName", userDetails.getFullName());
+    List<User> users = userDetailsService.getUsersByCompanyId(userDetails.getCompany().getCompanyId());
+    model.addAttribute("users", users);
+    return "/settings-user";
+  }
+
+  @PostMapping("/settings/user/update")
+  public String updateUserRole(@RequestParam Long userId,
+                              @RequestParam String role,
+                              RedirectAttributes redirectAttributes) {
+    try {
+      userDetailsService.updateUserRole(userId, role);
+      redirectAttributes.addFlashAttribute("success", "ユーザーのロールを更新しました。");
+    } catch (IllegalArgumentException ex) {
+      redirectAttributes.addFlashAttribute("error", ex.getMessage());
+    }
+    return "redirect:/settings/user";
+  }
 }

--- a/src/main/java/com/example/sharing_service_site/entity/Company.java
+++ b/src/main/java/com/example/sharing_service_site/entity/Company.java
@@ -27,5 +27,6 @@ public class Company {
   @OneToMany(mappedBy = "company")
   private List<User> users;
 
+  public Long getCompanyId() { return companyId; }
   public String getCompanyName() { return companyName; }
 }

--- a/src/main/java/com/example/sharing_service_site/entity/User.java
+++ b/src/main/java/com/example/sharing_service_site/entity/User.java
@@ -58,12 +58,26 @@ public class User {
   @JoinColumn(name = "department_id", nullable = false)
   private Department department;
 
+  public Long getUserId() { return UserId; }
   public String getEmployeeNumber() { return employeeNumber; }
   public String getPassword() { return password; }
   public String getFullName() { return fullName; }
   public Set<Role> getRoles() { return roles; }
   public Company getCompany() { return company; }
   public Department getDepartment() { return department; }
+  public String getRoleName() {
+    if (roles == null || roles.isEmpty()) {
+        return "閲覧のみ";
+    }
+
+    return roles.stream()
+            .map(Role::getRoleName)
+            .anyMatch("ADMIN"::equals) ? "管理者" :
+          roles.stream()
+            .map(Role::getRoleName)
+            .anyMatch("USER"::equals) ? "ユーザー" :
+          "閲覧のみ";
+  }
 
   public void setEmployeeNumber(String employeeNumber) { this.employeeNumber = employeeNumber; }
   public void setPassword(String password) { this.password = password; }

--- a/src/main/java/com/example/sharing_service_site/infrastructure/WebSecurityConfig.java
+++ b/src/main/java/com/example/sharing_service_site/infrastructure/WebSecurityConfig.java
@@ -16,7 +16,7 @@ public class WebSecurityConfig {
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.authorizeHttpRequests(auth -> auth
       .requestMatchers("/login", "/css/**", "/images/**").permitAll()
-      // .requestMatchers("/home").hasRole("USER") // 制限ページの設定不足
+      .requestMatchers("/settings/user").hasRole("ADMIN")
       .anyRequest().authenticated())
     .formLogin(login -> login
       .loginPage("/login")

--- a/src/main/java/com/example/sharing_service_site/repository/RoleRepository.java
+++ b/src/main/java/com/example/sharing_service_site/repository/RoleRepository.java
@@ -1,0 +1,17 @@
+package com.example.sharing_service_site.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.sharing_service_site.entity.Role;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+
+  /**
+   * ロールIDを基にロール情報を検索する
+   * @param roleId 検索対象のロールID
+   * @return 該当するロール情報
+   */
+  Optional<Role> findByRoleId(Long roleId);
+}

--- a/src/main/java/com/example/sharing_service_site/repository/UserRepository.java
+++ b/src/main/java/com/example/sharing_service_site/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.example.sharing_service_site.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +19,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
    * @return 該当するユーザー情報
    */
   Optional<User> findByEmployeeNumber(String employeeNumber);
+
+  /**
+   * 会社IDを基にユーザー情報を検索する
+   * @param companyId 検索対象の会社ID
+   * @return 該当するユーザー情報のリスト
+   */
+  List<User> findByCompanyCompanyId(Long companyId);
 }

--- a/src/main/java/com/example/sharing_service_site/service/CustomUserDetails.java
+++ b/src/main/java/com/example/sharing_service_site/service/CustomUserDetails.java
@@ -63,7 +63,7 @@ public class CustomUserDetails implements UserDetails {
             .map(Role::getRoleName)
             .anyMatch("USER"::equals) ? "ユーザー" :
           "閲覧のみ";
-}
+  }
 
   public String getEmployeeNumber() { return employeeNumber; }
   public String getFullName() { return fullName; }

--- a/src/main/java/com/example/sharing_service_site/service/CustomUserDetailsService.java
+++ b/src/main/java/com/example/sharing_service_site/service/CustomUserDetailsService.java
@@ -1,25 +1,33 @@
 package com.example.sharing_service_site.service;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import com.example.sharing_service_site.entity.Role;
 import com.example.sharing_service_site.entity.User;
+import com.example.sharing_service_site.repository.RoleRepository;
 import com.example.sharing_service_site.repository.UserRepository;
 
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
   private final UserRepository userRepository;
+  private final RoleRepository roleRepository;
 
-  public CustomUserDetailsService(UserRepository userRepository){
+  public CustomUserDetailsService(UserRepository userRepository, RoleRepository roleRepository) {
     this.userRepository = userRepository;
+    this.roleRepository = roleRepository;
   }
 
   @Override
   public UserDetails loadUserByUsername(String employeeNumber) throws UsernameNotFoundException {
     com.example.sharing_service_site.entity.User user = userRepository.findByEmployeeNumber(employeeNumber)
-        .orElseThrow(() -> new UsernameNotFoundException("社員番号が存在しません: " + employeeNumber));
+        .orElseThrow(() -> new UsernameNotFoundException("従業員番号が存在しません: " + employeeNumber));
 
     // 利用することができるログイン中のユーザー情報
     return new CustomUserDetails(
@@ -33,7 +41,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
   public void updatePassword(String employeeNumber, String encodedPassword) {
     com.example.sharing_service_site.entity.User user = userRepository.findByEmployeeNumber(employeeNumber)
-        .orElseThrow(() -> new UsernameNotFoundException("社員番号が存在しません: " + employeeNumber));
+        .orElseThrow(() -> new UsernameNotFoundException("従業員番号が存在しません: " + employeeNumber));
 
     user.setPassword(encodedPassword);
     userRepository.save(user);
@@ -41,6 +49,34 @@ public class CustomUserDetailsService implements UserDetailsService {
 
   public User getUser(String employeeNumber) {
     return userRepository.findByEmployeeNumber(employeeNumber)
-        .orElseThrow(() -> new UsernameNotFoundException("社員番号が存在しません: " + employeeNumber));
+        .orElseThrow(() -> new UsernameNotFoundException("従業員番号が存在しません: " + employeeNumber));
+  }
+
+  public List<User> getUsersByCompanyId(Long companyId) {
+    return userRepository.findByCompanyCompanyId(companyId);
+  }
+
+  public void updateUserRole(Long userId, String roleName) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new UsernameNotFoundException("ユーザーIDが存在しません: " + userId));
+    user.getRoles().clear();
+
+    Set<Role> newRoles = new HashSet<>();
+
+    if ("ADMIN".equals(roleName)) {
+      Role userRole = roleRepository.findById(1L)
+              .orElseThrow(() -> new IllegalArgumentException("USERロールが見つかりません"));
+      Role adminRole = roleRepository.findById(2L)
+              .orElseThrow(() -> new IllegalArgumentException("ADMINロールが見つかりません"));
+      newRoles.add(userRole);
+      newRoles.add(adminRole);
+    } else if ("USER".equals(roleName)) {
+      Role userRole = roleRepository.findById(1L)
+              .orElseThrow(() -> new IllegalArgumentException("USERロールが見つかりません"));
+      newRoles.add(userRole);
+    }
+
+    user.setRoles(newRoles);
+    userRepository.save(user);
   }
 }

--- a/src/main/resources/static/css/settings.css
+++ b/src/main/resources/static/css/settings.css
@@ -1,0 +1,73 @@
+.settings-button {
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  text-decoration: none;
+  transition: background-color 0.2s ease;
+}
+
+.settings-button:hover {
+  background-color: #0056b3;
+}
+
+.user-container {
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto;
+  gap: 10px;
+}
+
+.user-header {
+  display: grid;
+  grid-template-columns: 2fr 1fr 2fr 1fr;
+  font-weight: bold;
+  background-color: #f0f0f0;
+  padding: 10px;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.user-row {
+  display: grid;
+  grid-template-columns: 2fr 1fr 2fr 1fr;
+  align-items: center;
+  background-color: white;
+  padding: 10px;
+  border-radius: 6px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  transition: background-color 0.2s ease;
+}
+
+.user-row:hover {
+  background-color: #f9f9f9;
+}
+
+.user-item {
+  padding: 0 5px;
+}
+
+.role-select {
+  padding: 4px;
+  margin-right: 5px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+}
+
+.save-role-btn {
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.2s ease;
+}
+
+.save-role-btn:hover {
+  background-color: #0056b3;
+}

--- a/src/main/resources/static/js/settings.js
+++ b/src/main/resources/static/js/settings.js
@@ -1,0 +1,19 @@
+// document.querySelectorAll(".role-form").forEach((form) => {
+//   form.addEventListener("submit", async function (event) {
+//     event.preventDefault();
+
+//     const formData = new FormData(form);
+
+//     const response = await fetch(form.action, {
+//       method: "POST",
+//       body: formData,
+//     });
+
+//     if (response.ok) {
+//       const result = await response.json();
+//       alert(`ロールが「${result.newRoleName}」に変更されました。`);
+//     } else {
+//       alert("ロール変更に失敗しました。");
+//     }
+//   });
+// });

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -18,8 +18,8 @@
 
         <div class="profile-card">
           <div class="profile-item">
-            <span class="profile-label">従業員番号</span>
-            <span class="value" th:text="${username}">従業員番号</span>
+            <span class="profile-label">従業員ID</span>
+            <span class="value" th:text="${username}">従業員ID</span>
           </div>
 
           <div class="profile-item">

--- a/src/main/resources/templates/settings-user.html
+++ b/src/main/resources/templates/settings-user.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Sharing Service Site</title>
+    <link rel="stylesheet" th:href="@{/css/settings.css}" />
+    <link rel="stylesheet" th:href="@{/css/header.css}" />
+    <link rel="stylesheet" th:href="@{/css/sidebar.css}" />
+  </head>
+  <body>
+    <div th:replace="fragments/header :: header(${fullName})"></div>
+
+    <div class="layout">
+      <div th:replace="fragments/sidebar :: sidebar"></div>
+
+      <div class="main-content">
+        <h1>ユーザー管理</h1>
+        <div class="user-container" id="userContainer">
+          <div class="user-header">
+            <span class="header-item">氏名</span>
+            <span class="header-item">従業員ID</span>
+            <span class="header-item">部署</span>
+            <span class="header-item">ロール</span>
+          </div>
+
+          <div class="user-row" th:each="user : ${users}">
+            <span class="user-item" th:text="${user.fullName}"></span>
+            <span class="user-item" th:text="${user.employeeNumber}"></span>
+            <span
+              class="user-item"
+              th:text="${user.department.departmentName}"
+            ></span>
+
+            <form
+              class="role-form"
+              th:action="@{/settings/user/update}"
+              method="post"
+            >
+              <input type="hidden" name="userId" th:value="${user.userId}" />
+              <select class="role-select" name="role">
+                <option
+                  value="USER"
+                  th:selected="${user.roleName == 'ユーザー'}"
+                >
+                  ユーザー
+                </option>
+                <option
+                  value="ADMIN"
+                  th:selected="${user.roleName == '管理者'}"
+                >
+                  管理者
+                </option>
+                <option
+                  value="VIEWER"
+                  th:selected="${user.roleName == '閲覧のみ'}"
+                >
+                  閲覧のみ
+                </option>
+              </select>
+              <button class="save-role-btn" type="submit">変更</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script th:src="@{/js/sidebar.js}"></script>
+  </body>
+</html>

--- a/src/main/resources/templates/settings.html
+++ b/src/main/resources/templates/settings.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Sharing Service Site</title>
+    <link rel="stylesheet" th:href="@{/css/settings.css}" />
+    <link rel="stylesheet" th:href="@{/css/header.css}" />
+    <link rel="stylesheet" th:href="@{/css/sidebar.css}" />
+  </head>
+  <body>
+    <div th:replace="fragments/header :: header(${fullName})"></div>
+
+    <div class="layout">
+      <div th:replace="fragments/sidebar :: sidebar"></div>
+
+      <div class="main-content">
+        <h1>設定</h1>
+
+        <div class="settings-card">
+          <p>現在設定できる項目は存在していません。</p>
+
+          <div class="settings-actions" sec:authorize="hasRole('ADMIN')">
+            <a class="settings-button" th:href="@{/settings/user}">
+              ユーザー管理
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script th:src="@{/js/sidebar.js}"></script>
+  </body>
+</html>


### PR DESCRIPTION
# 概要
設定ページの作成とロール変更機能の実装

# 範囲
## やったこと
* 設定ページを作成し、管理者のみが行うことができるユーザー管理でロールの変更を行うことができる
* ロールは、管理者・ユーザー・閲覧のみから選ぶことができる。
* 現在は管理者のみユーザー管理ができるだけで、ユーザーと閲覧のみの違いは存在していない

## やっていないこと
* 一般ユーザーが行うことができる設定項目の表示
* 設定を保存するためのsettingsテーブルやエンティティなどの作成
* 新しいユーザーの追加機能の作成
* ユーザー管理でログインしているユーザー自身を管理者以外にできないようにするなどの制限(管理者がいなくなってしまうと問題のため)

## 動作確認
設定ページを開いて、管理者権限のあるユーザーでユーザー管理ボタンを押してロールの変更を行う。
別ユーザーを利用して確認するのがよい
**自分自身を管理者以外に変更してログアウトするとDBを直接操作しないと復元できない場合があるので注意**

Issue: #12 