### PR TITLE
設定項目の表示

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/AuthController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/AuthController.java
@@ -15,11 +15,13 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.example.sharing_service_site.entity.Department;
 import com.example.sharing_service_site.entity.Message;
+import com.example.sharing_service_site.entity.Settings;
 import com.example.sharing_service_site.entity.User;
 import com.example.sharing_service_site.service.CustomUserDetails;
 import com.example.sharing_service_site.service.CustomUserDetailsService;
 import com.example.sharing_service_site.service.DepartmentService;
 import com.example.sharing_service_site.service.MessageService;
+import com.example.sharing_service_site.service.SettingsService;
 
 @Controller
 public class AuthController {
@@ -27,11 +29,13 @@ public class AuthController {
   private final CustomUserDetailsService userDetailsService;
   private final DepartmentService departmentService;
   private final MessageService messageService;
+  private final SettingsService settingsService;
 
-  public AuthController(DepartmentService departmentService, MessageService messageService, CustomUserDetailsService userDetailsService) {
+  public AuthController(DepartmentService departmentService, MessageService messageService, CustomUserDetailsService userDetailsService, SettingsService settingsService) {
     this.departmentService = departmentService;
     this.messageService = messageService;
     this.userDetailsService = userDetailsService;
+    this.settingsService = settingsService;
   }
 
   @GetMapping("/login")
@@ -148,6 +152,9 @@ public class AuthController {
   @GetMapping("/settings")
   public String settings(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
     model.addAttribute("fullName", userDetails.getFullName());
+
+    Settings settings = settingsService.getSettingsByUserId(userDetails.getUserId());
+    model.addAttribute("settings", settings);
     return "/settings";
   }
 

--- a/src/main/java/com/example/sharing_service_site/entity/Company.java
+++ b/src/main/java/com/example/sharing_service_site/entity/Company.java
@@ -2,6 +2,7 @@ package com.example.sharing_service_site.entity;
 
 import java.util.List;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,8 +18,11 @@ import jakarta.persistence.Table;
 public class Company {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "company_id")
   private Long companyId;
 
+  // DBにはユニーク制約なし
+  @Column(name = "company_name", nullable = false, unique = true)
   private String companyName;
 
   @OneToMany(mappedBy = "company")
@@ -29,4 +33,6 @@ public class Company {
 
   public Long getCompanyId() { return companyId; }
   public String getCompanyName() { return companyName; }
+  public List<Department> getDepartments() { return departments; }
+  public List<User> getUsers() { return users; }
 }

--- a/src/main/java/com/example/sharing_service_site/entity/Department.java
+++ b/src/main/java/com/example/sharing_service_site/entity/Department.java
@@ -2,6 +2,7 @@ package com.example.sharing_service_site.entity;
 
 import java.util.List;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -19,8 +20,10 @@ import jakarta.persistence.Table;
 public class Department {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "department_id")
   private Long departmentId;
 
+  @Column(name = "department_name", nullable = false)
   private String departmentName;
 
   @ManyToOne
@@ -29,7 +32,7 @@ public class Department {
 
   @ManyToOne
   @JoinColumn(name = "parent_id")
-  private Department parent;
+  private Department parent = null;
 
   @OneToMany(mappedBy = "parent")
   private List<Department> children;
@@ -39,5 +42,8 @@ public class Department {
 
   public Long getDepartmentId() { return departmentId; }
   public String getDepartmentName() { return departmentName; }
+  public Company getCompany() { return company; }
   public Department getParent() { return parent; }
+  public List<Department> getChildren() { return children; }
+  public List<User> getUsers() { return users; }
 }

--- a/src/main/java/com/example/sharing_service_site/entity/Message.java
+++ b/src/main/java/com/example/sharing_service_site/entity/Message.java
@@ -20,6 +20,7 @@ import jakarta.persistence.Table;
 public class Message {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "message_id")
   private Long messageId;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -30,13 +31,16 @@ public class Message {
   @JoinColumn(name = "user_id", nullable = false)
   private User author;
 
-  @Column(nullable = false, columnDefinition = "TEXT")
+  @Column(name = "content", nullable = false, columnDefinition = "TEXT")
   private String content;
 
+  @Column(name = "created_at", nullable = false, updatable = false)
   private LocalDateTime createdAt;
 
+  @Column(name = "updated_at")
   private LocalDateTime updatedAt;
 
+  @Column(name = "edited", nullable = false)
   private boolean edited = false;
 
   public Message() {}
@@ -49,7 +53,7 @@ public class Message {
     this.edited = false;
   }
 
-  public Long getId() { return messageId; }
+  public Long getMessageId() { return messageId; }
   public Department getDepartment() { return department; }
   public User getAuthor() { return author; }
   public String getContent() { return content; }

--- a/src/main/java/com/example/sharing_service_site/entity/Role.java
+++ b/src/main/java/com/example/sharing_service_site/entity/Role.java
@@ -2,6 +2,7 @@ package com.example.sharing_service_site.entity;
 
 import java.util.List;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,12 +18,18 @@ import jakarta.persistence.Table;
 public class Role {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "role_id")
   private Long roleId;
 
+  // rolesテーブルのrole_nameカラムをDEFAULT NULLでないように変更する
+  // DBにはユニーク制約なし
+  @Column(name = "role_name", nullable = false, unique = true)
   private String roleName;
 
   @OneToMany(mappedBy = "roles")
   private List<User> users;
 
+  public Long getRoleId() { return roleId; }
   public String getRoleName() { return roleName; }
+  public List<User> getUsers() { return users; }
 }

--- a/src/main/java/com/example/sharing_service_site/entity/Settings.java
+++ b/src/main/java/com/example/sharing_service_site/entity/Settings.java
@@ -1,0 +1,43 @@
+package com.example.sharing_service_site.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "settings")
+public class Settings {
+  @Id
+  @Column(name = "user_id")
+  private Long userId;
+
+  @OneToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Column(name = "theme_color", nullable = false)
+  private String themeColor = "navy-blue";
+
+  @Column(name = "department_order", nullable = false)
+  private String departmentOrder = "created-date";
+
+  public Settings() {}
+
+  public Settings(User user, String themeColor) {
+    this.user = user;
+    this.themeColor = themeColor;
+  }
+
+  public Long getUserId() { return userId; }
+  public User getUser() { return user; }
+  
+  // 以下、各種設定項目のゲッター・セッターを追加
+  public String getThemeColor() { return themeColor; }
+  public void setThemeColor(String themeColor) { this.themeColor = themeColor; }
+
+  public String getDepartmentOrder() { return departmentOrder; }
+  public void setDepartmentOrder(String departmentOrder) { this.departmentOrder = departmentOrder; }
+}

--- a/src/main/java/com/example/sharing_service_site/entity/User.java
+++ b/src/main/java/com/example/sharing_service_site/entity/User.java
@@ -3,6 +3,7 @@ package com.example.sharing_service_site.entity;
 import java.util.HashSet;
 import java.util.Set;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -26,20 +27,25 @@ public class User {
    */
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long UserId;
+  @Column(name = "user_id")
+  private Long userId;
 
   /**
    * 従業員番号。ユーザーを識別するユニークな情報として利用する。
    */
+  // DBではデフォルトがNULL許容なので、NOT NULLに変更する。以下同様
+  @Column(name = "employee_number", unique = true)
   private String employeeNumber;
   /**
    * パスワード。ハッシュ化された状態で保持され、認証に利用する。
    */
+  @Column(name = "password", nullable = false)
   private String password;
   
   /**
    * 表示名。表示のためだけに扱われる。
    */
+  @Column(name = "full_name")
   private String fullName;
 
   @ManyToMany(fetch = FetchType.EAGER)
@@ -58,7 +64,7 @@ public class User {
   @JoinColumn(name = "department_id", nullable = false)
   private Department department;
 
-  public Long getUserId() { return UserId; }
+  public Long getUserId() { return userId; }
   public String getEmployeeNumber() { return employeeNumber; }
   public String getPassword() { return password; }
   public String getFullName() { return fullName; }
@@ -69,7 +75,6 @@ public class User {
     if (roles == null || roles.isEmpty()) {
         return "閲覧のみ";
     }
-
     return roles.stream()
             .map(Role::getRoleName)
             .anyMatch("ADMIN"::equals) ? "管理者" :

--- a/src/main/java/com/example/sharing_service_site/repository/SettingsRepository.java
+++ b/src/main/java/com/example/sharing_service_site/repository/SettingsRepository.java
@@ -1,0 +1,21 @@
+package com.example.sharing_service_site.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.sharing_service_site.entity.Settings;
+
+/**
+ * 設定情報のDB操作を行う
+ */
+public interface SettingsRepository extends JpaRepository<Settings, Long> {
+
+  /**
+   * ユーザーIDを基に設定情報を検索する
+   * 
+   * @param userId 検索対象のユーザーID
+   * @return 該当する設定情報一覧
+   */
+  Optional<Settings> findByUserUserId(Long userId);
+}

--- a/src/main/java/com/example/sharing_service_site/service/CustomUserDetails.java
+++ b/src/main/java/com/example/sharing_service_site/service/CustomUserDetails.java
@@ -13,6 +13,7 @@ import com.example.sharing_service_site.entity.Department;
 import com.example.sharing_service_site.entity.Role;
 
 public class CustomUserDetails implements UserDetails {
+  private final Long userId;
   private final String employeeNumber;
   private final String password;
   private final Set<Role> roles;
@@ -22,6 +23,7 @@ public class CustomUserDetails implements UserDetails {
 
   /**
    * 利用することができるログイン中のユーザー情報
+   * @param userId ユーザーID
    * @param employeeNumber 従業員番号
    * @param password パスワード
    * @param roles 権限(ロール)
@@ -29,7 +31,8 @@ public class CustomUserDetails implements UserDetails {
    * @param company 所属会社
    * @param department 所属部署
    */
-  public CustomUserDetails(String employeeNumber, String password, Set<Role> roles, String fullName, Company company, Department department) {
+  public CustomUserDetails(Long userId, String employeeNumber, String password, Set<Role> roles, String fullName, Company company, Department department) {
+      this.userId = userId;
       this.employeeNumber = employeeNumber;
       this.password = password;
       this.roles = roles;
@@ -65,6 +68,7 @@ public class CustomUserDetails implements UserDetails {
           "閲覧のみ";
   }
 
+  public Long getUserId() { return userId; }
   public String getEmployeeNumber() { return employeeNumber; }
   public String getFullName() { return fullName; }
   public Company getCompany() { return company; }

--- a/src/main/java/com/example/sharing_service_site/service/CustomUserDetailsService.java
+++ b/src/main/java/com/example/sharing_service_site/service/CustomUserDetailsService.java
@@ -31,6 +31,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     // 利用することができるログイン中のユーザー情報
     return new CustomUserDetails(
+        user.getUserId(),
         user.getEmployeeNumber(),
         user.getPassword(),
         user.getRoles(),

--- a/src/main/java/com/example/sharing_service_site/service/DepartmentService.java
+++ b/src/main/java/com/example/sharing_service_site/service/DepartmentService.java
@@ -18,6 +18,9 @@ public class DepartmentService {
 
   /**
    * 会社名を指定して、ルート部署（親がnullの部署）を取得する
+   * 
+   * @param company 会社エンティティ
+   * @return ルート部署一覧
    */
   public List<Department> getRootDepartmentsByCompany(Company company) {
     List<Department> allDepartments = departmentRepository.findByCompany(company);
@@ -28,6 +31,10 @@ public class DepartmentService {
 
   /**
    * 部署IDを指定して、その子部署一覧を取得する
+   * 
+   * @param parentDepartmentId 親部署ID
+   * @return 子部署一覧
+   * @throws IllegalArgumentException 親部署が見つからない場合
    */
   public List<Department> getChildDepartments(Long parentDepartmentId) {
     Optional<Department> parentOpt = departmentRepository.findById(parentDepartmentId);
@@ -39,6 +46,9 @@ public class DepartmentService {
 
   /**
    * 部署IDを指定して、その部署名を取得する
+   * 
+   * @param departmentId 部署ID
+   * @return 部署名（部署が見つからない場合はnullを返す）
    */
   public String getDepartmentNameById(Long departmentId) {
     return departmentRepository.findById(departmentId)

--- a/src/main/java/com/example/sharing_service_site/service/MessageService.java
+++ b/src/main/java/com/example/sharing_service_site/service/MessageService.java
@@ -19,10 +19,25 @@ public class MessageService {
   @Autowired
   private DepartmentRepository departmentRepository;
 
+  /**
+   * 部署IDを基にメッセージを取得する
+   * 
+   * @param departmentId 部署ID
+   * @return 該当するメッセージ一覧
+   */
   public List<Message> getMessagesByDepartmentId(Long departmentId) {
     return messageRepository.findByDepartmentDepartmentIdOrderByCreatedAtAsc(departmentId);
   }
 
+  /**
+   * メッセージを保存する
+   * 
+   * @param departmentId 部署ID
+   * @param author       投稿者ユーザー
+   * @param content      メッセージ内容
+   * @return 保存されたメッセージ
+   * @throws IllegalArgumentException 部署が見つからない場合
+   */
   public Message saveMessage(Long departmentId, User author, String content) {
     Department department = departmentRepository.findById(departmentId)
         .orElseThrow(() -> new IllegalArgumentException("部署が見つかりません: " + departmentId));

--- a/src/main/java/com/example/sharing_service_site/service/SettingsService.java
+++ b/src/main/java/com/example/sharing_service_site/service/SettingsService.java
@@ -1,0 +1,36 @@
+package com.example.sharing_service_site.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.example.sharing_service_site.entity.Settings;
+import com.example.sharing_service_site.repository.SettingsRepository;
+
+@Service
+public class SettingsService {
+  @Autowired
+  private SettingsRepository settingsRepository;
+  
+  /**
+   * ユーザーIDを基に設定情報を取得する
+   * 
+   * @param userId ユーザーID
+   * @return 該当する設定情報一覧
+   */
+  public Settings getSettingsByUserId(Long userId) {
+    return settingsRepository.findByUserUserId(userId)
+        .orElseThrow(() -> new IllegalArgumentException("設定情報が存在しません: " + userId));
+  }
+
+  // 以下、各種設定項目の更新メソッドを追加
+  /**
+   * テーマカラーを更新する
+   * @param themeColor 更新後のテーマカラー
+   */
+  public Settings updateThemeColor(Long userId, String themeColor) {
+    Settings settings = settingsRepository.findByUserUserId(userId)
+        .orElseThrow(() -> new IllegalArgumentException("設定情報が存在しません: " + userId));
+    settings.setThemeColor(themeColor);
+    return settingsRepository.save(settings);
+  }
+}

--- a/src/main/resources/templates/settings.html
+++ b/src/main/resources/templates/settings.html
@@ -17,7 +17,15 @@
         <h1>設定</h1>
 
         <div class="settings-card">
-          <p>現在設定できる項目は存在していません。</p>
+          <div class="settings-card">
+            <h2>ユーザー設定</h2>
+
+            <!-- 項目をテキストで表示 -->
+            <div th:each="setting : ${settings}">
+              <p>テーマカラー: <span th:text="${setting.themeColor}"></span></p>
+              <p>部署の並び順: <span th:text="${setting.departmentOrder}"></span></p>
+            </div>
+          </div>
 
           <div class="settings-actions" sec:authorize="hasRole('ADMIN')">
             <a class="settings-button" th:href="@{/settings/user}">


### PR DESCRIPTION
# 概要
それぞれのユーザーが持つ複数の設定項目情報をDBから読み込み、表示する。

# 範囲
## やったこと
* DBからエンティティ、リポジトリ、サービスとコントローラーの追加、また設定ページの追加修正
* 全エンティティの見直し

## やっていないこと
* 各設定項目の変更と反映
* エンティティの制約を正確に記述していない


# 動作確認
* 各ユーザーで設定ページを開いてそれぞれの設定が表示されているか確認する
* 設定項目を追加するときは、
1.DBにカラム追加
2.エンティティに値とゲッターを作成
3.サービスに更新メソッドを作成(現在は動作が行われない)
4.HTMLに追加(現在はテキストのみ)

Issue: #29 