### PR TITLE
ロール変更の制限

### DIFF
--- a/src/main/resources/static/css/settings.css
+++ b/src/main/resources/static/css/settings.css
@@ -42,10 +42,6 @@
   transition: background-color 0.2s ease;
 }
 
-.user-row:hover {
-  background-color: #f9f9f9;
-}
-
 .user-item {
   padding: 0 5px;
 }

--- a/src/main/resources/templates/settings-user.html
+++ b/src/main/resources/templates/settings-user.html
@@ -30,11 +30,11 @@
               class="user-item"
               th:text="${user.department.departmentName}"
             ></span>
-
             <form
               class="role-form"
               th:action="@{/settings/user/update}"
               method="post"
+              th:if="${user.fullName != fullName}"
             >
               <input type="hidden" name="userId" th:value="${user.userId}" />
               <select class="role-select" name="role">
@@ -59,6 +59,11 @@
               </select>
               <button class="save-role-btn" type="submit">変更</button>
             </form>
+            <span
+              class="user-item"
+              th:text="${user.roleName}"
+              th:unless="${user.fullName != fullName}"
+            ></span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# 概要
管理者がユーザー管理でロールを変更する際に、自分自身のロールを管理者以外に変更できなくすることで、サービスを利用する会社の従業員に管理者がいなくなってしまう事態を避ける

# 範囲
ユーザー管理ページ

# 動作確認
管理者でログイン後、ユーザー管理画面で自分のロールが変更できないことを確認する

Issue: #31 