### PR TITLE
メッセージ送信機能の制限

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/AuthController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/AuthController.java
@@ -73,6 +73,7 @@ public class AuthController {
                         @AuthenticationPrincipal CustomUserDetails userDetails,
                         @RequestParam Long departmentId) {
     model.addAttribute("fullName", userDetails.getFullName());
+    model.addAttribute("roleName", userDetails.getRoleName());
     model.addAttribute("departmentId", departmentId);
 
     User user = userDetailsService.getUser(userDetails.getEmployeeNumber());

--- a/src/main/resources/static/css/message.css
+++ b/src/main/resources/static/css/message.css
@@ -7,6 +7,15 @@
   gap: 8px;
 }
 
+.message-list-viewer {
+  list-style: none;
+  padding: 0;
+  margin-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .message-card {
   background: #f8f9fa;
   border-radius: 10px;

--- a/src/main/resources/templates/message.html
+++ b/src/main/resources/templates/message.html
@@ -22,7 +22,7 @@
           部署名の掲示板
         </h1>
 
-        <ul class="message-list">
+        <ul class="message-list" th:classappend="${roleName != '閲覧のみ'} ? ' message-list' : ' message-list-viewer'">
           <li class="message-card" th:each="msg : ${messages}">
             <div class="message-header">
               <b class="message-name" th:text="${msg.authorName}">名前</b>
@@ -36,7 +36,7 @@
           </li>
         </ul>
 
-        <div class="message-input-area">
+        <div class="message-input-area" th:if="${roleName != '閲覧のみ'}">
           <form class="message-form" th:action="@{/message/send}" method="post">
             <input
               type="hidden"


### PR DESCRIPTION
# 概要
閲覧のみユーザーがメッセージを送信できないようにする

# 範囲
* 閲覧のみユーザーのメッセージ入力フォームとボタンの非表示
* それに伴ったスペースの調整

# 動作確認
閲覧のみユーザーでログインしてメッセージページを確認する

Issue: #33 