### PR TITLE
部署が適切に表示されないバグを修正

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/AuthController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/AuthController.java
@@ -69,6 +69,7 @@ public class AuthController {
                         @AuthenticationPrincipal CustomUserDetails userDetails,
                         @RequestParam Long departmentId) {
     model.addAttribute("fullName", userDetails.getFullName());
+    model.addAttribute("roleName", userDetails.getRoleName());
     model.addAttribute("departmentId", departmentId);
 
     User user = userDetailsService.getUser(userDetails.getEmployeeNumber());

--- a/src/main/java/com/example/sharing_service_site/controller/AuthController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/AuthController.java
@@ -15,11 +15,13 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.example.sharing_service_site.entity.Department;
 import com.example.sharing_service_site.entity.Message;
+import com.example.sharing_service_site.entity.Settings;
 import com.example.sharing_service_site.entity.User;
 import com.example.sharing_service_site.service.CustomUserDetails;
 import com.example.sharing_service_site.service.CustomUserDetailsService;
 import com.example.sharing_service_site.service.DepartmentService;
 import com.example.sharing_service_site.service.MessageService;
+import com.example.sharing_service_site.service.SettingsService;
 
 @Controller
 public class AuthController {
@@ -27,11 +29,16 @@ public class AuthController {
   private final CustomUserDetailsService userDetailsService;
   private final DepartmentService departmentService;
   private final MessageService messageService;
+  private final SettingsService settingsService;
 
-  public AuthController(DepartmentService departmentService, MessageService messageService, CustomUserDetailsService userDetailsService) {
+  public AuthController(CustomUserDetailsService userDetailsService, 
+                        DepartmentService departmentService, 
+                        MessageService messageService, 
+                        SettingsService settingsService) {
+    this.userDetailsService = userDetailsService;
     this.departmentService = departmentService;
     this.messageService = messageService;
-    this.userDetailsService = userDetailsService;
+    this.settingsService = settingsService;
   }
 
   @GetMapping("/login")
@@ -149,6 +156,8 @@ public class AuthController {
   @GetMapping("/settings")
   public String settings(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
     model.addAttribute("fullName", userDetails.getFullName());
+    Settings settings = settingsService.getSettingsByUserId(userDetails.getUserId());
+    model.addAttribute("settings", settings);
     return "/settings";
   }
 

--- a/src/main/java/com/example/sharing_service_site/entity/Settings.java
+++ b/src/main/java/com/example/sharing_service_site/entity/Settings.java
@@ -1,0 +1,43 @@
+package com.example.sharing_service_site.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "settings")
+public class Settings {
+  @Id
+  @Column(name = "user_id")
+  private Long userId;
+
+  @OneToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Column(name = "theme_color", nullable = false)
+  private String themeColor = "navy-blue";
+
+  @Column(name = "department_order", nullable = false)
+  private String departmentOrder = "created-date";
+
+  public Settings() {}
+
+  public Settings(User user, String themeColor) {
+    this.user = user;
+    this.themeColor = themeColor;
+  }
+
+  public Long getUserId() { return userId; }
+  public User getUser() { return user; }
+
+  // 以下、各種設定項目のゲッター・セッターを追加
+  public String getThemeColor() { return themeColor; }
+  public void setThemeColor(String themeColor) { this.themeColor = themeColor; }
+
+  public String getDepartmentOrder() { return departmentOrder; }
+  public void setDepartmentOrder(String departmentOrder) { this.departmentOrder = departmentOrder; }
+}

--- a/src/main/java/com/example/sharing_service_site/entity/User.java
+++ b/src/main/java/com/example/sharing_service_site/entity/User.java
@@ -26,7 +26,7 @@ public class User {
    */
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long UserId;
+  private Long userId;
 
   /**
    * 従業員番号。ユーザーを識別するユニークな情報として利用する。
@@ -58,7 +58,7 @@ public class User {
   @JoinColumn(name = "department_id", nullable = false)
   private Department department;
 
-  public Long getUserId() { return UserId; }
+  public Long getUserId() { return userId; }
   public String getEmployeeNumber() { return employeeNumber; }
   public String getPassword() { return password; }
   public String getFullName() { return fullName; }
@@ -69,7 +69,6 @@ public class User {
     if (roles == null || roles.isEmpty()) {
         return "閲覧のみ";
     }
-
     return roles.stream()
             .map(Role::getRoleName)
             .anyMatch("ADMIN"::equals) ? "管理者" :

--- a/src/main/java/com/example/sharing_service_site/repository/SettingsRepository.java
+++ b/src/main/java/com/example/sharing_service_site/repository/SettingsRepository.java
@@ -1,0 +1,21 @@
+package com.example.sharing_service_site.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.sharing_service_site.entity.Settings;
+
+/**
+ * 設定情報のDB操作を行う
+ */
+public interface SettingsRepository extends JpaRepository<Settings, Long> {
+
+  /**
+   * ユーザーIDを基に設定情報を検索する
+   * 
+   * @param userId 検索対象のユーザーID
+   * @return 該当する設定情報一覧
+   */
+  Optional<Settings> findByUserUserId(Long userId);
+}

--- a/src/main/java/com/example/sharing_service_site/service/CustomUserDetails.java
+++ b/src/main/java/com/example/sharing_service_site/service/CustomUserDetails.java
@@ -13,6 +13,7 @@ import com.example.sharing_service_site.entity.Department;
 import com.example.sharing_service_site.entity.Role;
 
 public class CustomUserDetails implements UserDetails {
+  private final Long userId;
   private final String employeeNumber;
   private final String password;
   private final Set<Role> roles;
@@ -22,6 +23,7 @@ public class CustomUserDetails implements UserDetails {
 
   /**
    * 利用することができるログイン中のユーザー情報
+   * @param userId ユーザーID
    * @param employeeNumber 従業員番号
    * @param password パスワード
    * @param roles 権限(ロール)
@@ -29,7 +31,8 @@ public class CustomUserDetails implements UserDetails {
    * @param company 所属会社
    * @param department 所属部署
    */
-  public CustomUserDetails(String employeeNumber, String password, Set<Role> roles, String fullName, Company company, Department department) {
+  public CustomUserDetails(Long userId, String employeeNumber, String password, Set<Role> roles, String fullName, Company company, Department department) {
+      this.userId = userId;
       this.employeeNumber = employeeNumber;
       this.password = password;
       this.roles = roles;
@@ -65,6 +68,7 @@ public class CustomUserDetails implements UserDetails {
           "閲覧のみ";
   }
 
+  public Long getUserId() { return userId; }
   public String getEmployeeNumber() { return employeeNumber; }
   public String getFullName() { return fullName; }
   public Company getCompany() { return company; }

--- a/src/main/java/com/example/sharing_service_site/service/CustomUserDetailsService.java
+++ b/src/main/java/com/example/sharing_service_site/service/CustomUserDetailsService.java
@@ -31,6 +31,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     // 利用することができるログイン中のユーザー情報
     return new CustomUserDetails(
+        user.getUserId(),
         user.getEmployeeNumber(),
         user.getPassword(),
         user.getRoles(),

--- a/src/main/java/com/example/sharing_service_site/service/SettingsService.java
+++ b/src/main/java/com/example/sharing_service_site/service/SettingsService.java
@@ -1,0 +1,36 @@
+package com.example.sharing_service_site.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.example.sharing_service_site.entity.Settings;
+import com.example.sharing_service_site.repository.SettingsRepository;
+
+@Service
+public class SettingsService {
+  @Autowired
+  private SettingsRepository settingsRepository;
+
+  /**
+   * ユーザーIDを基に設定情報を取得する
+   * 
+   * @param userId ユーザーID
+   * @return 該当する設定情報一覧
+   */
+  public Settings getSettingsByUserId(Long userId) {
+    return settingsRepository.findByUserUserId(userId)
+        .orElseThrow(() -> new IllegalArgumentException("設定情報が存在しません: " + userId));
+  }
+
+  // 以下、各種設定項目の更新メソッドを追加
+  /**
+   * テーマカラーを更新する
+   * @param themeColor 更新後のテーマカラー
+   */
+  public Settings updateThemeColor(Long userId, String themeColor) {
+    Settings settings = settingsRepository.findByUserUserId(userId)
+        .orElseThrow(() -> new IllegalArgumentException("設定情報が存在しません: " + userId));
+    settings.setThemeColor(themeColor);
+    return settingsRepository.save(settings);
+  }
+}

--- a/src/main/resources/static/css/message.css
+++ b/src/main/resources/static/css/message.css
@@ -7,6 +7,15 @@
   gap: 8px;
 }
 
+.message-list-viewer {
+  list-style: none;
+  padding: 0;
+  margin-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .message-card {
   background: #f8f9fa;
   border-radius: 10px;

--- a/src/main/resources/static/css/settings.css
+++ b/src/main/resources/static/css/settings.css
@@ -42,10 +42,6 @@
   transition: background-color 0.2s ease;
 }
 
-.user-row:hover {
-  background-color: #f9f9f9;
-}
-
 .user-item {
   padding: 0 5px;
 }

--- a/src/main/resources/static/css/settings.css
+++ b/src/main/resources/static/css/settings.css
@@ -67,3 +67,23 @@
 .save-role-btn:hover {
   background-color: #0056b3;
 }
+
+.toast {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: #333;
+  color: #fff;
+  padding: 12px 20px;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.5s, transform 0.5s;
+  z-index: 30;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/src/main/resources/static/js/settings.js
+++ b/src/main/resources/static/js/settings.js
@@ -1,19 +1,9 @@
-// document.querySelectorAll(".role-form").forEach((form) => {
-//   form.addEventListener("submit", async function (event) {
-//     event.preventDefault();
-
-//     const formData = new FormData(form);
-
-//     const response = await fetch(form.action, {
-//       method: "POST",
-//       body: formData,
-//     });
-
-//     if (response.ok) {
-//       const result = await response.json();
-//       alert(`ロールが「${result.newRoleName}」に変更されました。`);
-//     } else {
-//       alert("ロール変更に失敗しました。");
-//     }
-//   });
-// });
+window.addEventListener("DOMContentLoaded", () => {
+  const toast = document.getElementById("toast");
+  if (toast) {
+    toast.classList.add("show");
+    setTimeout(() => {
+      toast.classList.remove("show");
+    }, 3000);
+  }
+});

--- a/src/main/resources/templates/message.html
+++ b/src/main/resources/templates/message.html
@@ -22,7 +22,7 @@
           部署名の掲示板
         </h1>
 
-        <ul class="message-list">
+        <ul class="message-list" th:classappend="${roleName != '閲覧のみ'} ? ' message-list' : ' message-list-viewer'">
           <li class="message-card" th:each="msg : ${messages}">
             <div class="message-header">
               <b class="message-name" th:text="${msg.authorName}">名前</b>
@@ -36,7 +36,7 @@
           </li>
         </ul>
 
-        <div class="message-input-area">
+        <div class="message-input-area" th:if="${roleName != '閲覧のみ'}">
           <form class="message-form" th:action="@{/message/send}" method="post">
             <input
               type="hidden"

--- a/src/main/resources/templates/settings-user.html
+++ b/src/main/resources/templates/settings-user.html
@@ -30,11 +30,11 @@
               class="user-item"
               th:text="${user.department.departmentName}"
             ></span>
-
             <form
               class="role-form"
               th:action="@{/settings/user/update}"
               method="post"
+              th:if="${user.fullName != fullName}"
             >
               <input type="hidden" name="userId" th:value="${user.userId}" />
               <select class="role-select" name="role">
@@ -59,6 +59,11 @@
               </select>
               <button class="save-role-btn" type="submit">変更</button>
             </form>
+            <span
+              class="user-item"
+              th:text="${user.roleName}"
+              th:unless="${user.fullName != fullName}"
+            ></span>
           </div>
         </div>
       </div>

--- a/src/main/resources/templates/settings-user.html
+++ b/src/main/resources/templates/settings-user.html
@@ -66,9 +66,17 @@
             ></span>
           </div>
         </div>
+
+        <div
+          class="toast"
+          id="toast"
+          th:if="${success != null or error != null}"
+          th:text="${success != null ? success : error}"
+        ></div>
       </div>
     </div>
 
+    <script th:src="@{/js/settings.js}"></script>
     <script th:src="@{/js/sidebar.js}"></script>
   </body>
 </html>

--- a/src/main/resources/templates/settings.html
+++ b/src/main/resources/templates/settings.html
@@ -17,7 +17,15 @@
         <h1>設定</h1>
 
         <div class="settings-card">
-          <p>現在設定できる項目は存在していません。</p>
+          <div class="settings-card">
+            <h2>ユーザー設定</h2>
+
+            <!-- 項目をテキストで表示 -->
+            <div th:each="setting : ${settings}">
+              <p>テーマカラー: <span th:text="${setting.themeColor}"></span></p>
+              <p>部署の並び順: <span th:text="${setting.departmentOrder}"></span></p>
+            </div>
+          </div>
 
           <div class="settings-actions" sec:authorize="hasRole('ADMIN')">
             <a class="settings-button" th:href="@{/settings/user}">


### PR DESCRIPTION
# 概要
ホーム画面で部署カードをクリックした後、すべての子部署が表示されないバグを修正
このバグは「設定項目の表示」というコミットで発生した

# 範囲
* 設定項目の表示
* ロール変更の制限
* メッセージ送信機能の制限
* トースト表示の実装
これらのコミットを調整した

# 修正方法
原因のコミットである、「設定項目の表示」より一つ前のコミットから、**範囲**における問題のない下三つのコミットを一つずつ「git cherry-pick コミットID」のコマンドで修復し、最後に「設定項目の表示」コミットで問題のないコードの追加を行った。

# 考えられる原因
修正の結果、すべてのエンティティのjavadocコメントや@Columnの追加、ゲッターやセッターの追加やメソッド名の修正などが行われていたため、その部分に不具合が含まれていたと思われる。

# 同じような問題を起こさないために
* 一つの機能追加のIssueに対するPRだったのに対して、関係のない修正を含むコードの改変が多く含まれ、14ファイルにまたがる変更があったので、できるだけ最小限の変更でPRを出す必要があった。
* どんな小さいものでもIssueを立てて、小さなPRを出すことでバグの原因解明や修正が容易になるため、次からは変更するファイル数やPRの範囲に注意を払う必要がある。
