### PR TITLE
部署が適切に表示されないバグを修正

### DIFF
--- a/src/main/java/com/example/sharing_service_site/entity/Department.java
+++ b/src/main/java/com/example/sharing_service_site/entity/Department.java
@@ -42,8 +42,8 @@ public class Department {
 
   public Long getDepartmentId() { return departmentId; }
   public String getDepartmentName() { return departmentName; }
-  public Company getCompany() { return company; }
+  // public Company getCompany() { return company; } // 追加すると部署が適切に表示されない
   public Department getParent() { return parent; }
-  public List<Department> getChildren() { return children; }
+  // public List<Department> getChildren() { return children; } // 追加すると部署が適切に表示されない
   public List<User> getUsers() { return users; }
 }


### PR DESCRIPTION
# 概要
ホーム画面で部署カードをクリックした後、すべての子部署が表示されないバグを修正
このバグは「設定項目の表示」というコミットで発生した

# 範囲
**Department.java**
~~* 設定項目の表示~~  
~~* ロール変更の制限~~  
~~* メッセージ送信機能の制限~~  
~~* トースト表示の実装~~  
~~これらのコミットを調整した~~

# 修正方法
**Department.javaでcompanyとchildrenのゲッターを削除した**
* 過去のコミットの状態で実行して問題が発生したコミットを特定する
* 問題のないコミットを一つずつ反映させたブランチを作成する
* 影響が少ないと思われるファイルから反映させていき、問題のあるコードを特定した

~~原因のコミットである、「設定項目の表示」より一つ前のコミットから、**範囲**における問題のない下三つのコミットを一つずつ「git cherry-pick コミットID」のコマンドで修復し、最後に「設定項目の表示」コミットで問題のないコードの追加を行った。~~

# 考えられる原因
**ゲッターの追加による影響だが、現在は詳しくわかっていない。**
~~修正の結果、すべてのエンティティのjavadocコメントや@Columnの追加、ゲッターやセッターの追加やメソッド名の修正などが行われていたため、その部分に不具合が含まれていたと思われる。~~

# 同じような問題を起こさないために
* 一つの機能追加のIssueに対するPRだったのに対して、関係のない修正を含むコードの改変が多く含まれ、14ファイルにまたがる変更があったので、できるだけ最小限の変更でPRを出す必要があった。
* どんな小さいものでもIssueを立てて、小さなPRを出すことでバグの原因解明や修正が容易になるため、次からは変更するファイル数やPRの範囲に注意を払う必要がある。
