### PR TITLE
部署表示されないバグの完全な修正

### DIFF
--- a/src/main/java/com/example/sharing_service_site/entity/Department.java
+++ b/src/main/java/com/example/sharing_service_site/entity/Department.java
@@ -45,5 +45,5 @@ public class Department {
   // public Company getCompany() { return company; } // 追加すると部署が適切に表示されない
   public Department getParent() { return parent; }
   // public List<Department> getChildren() { return children; } // 追加すると部署が適切に表示されない
-  public List<User> getUsers() { return users; }
+  // public List<User> getUsers() { return users; } // 追加すると部署が適切に表示されない
 }


### PR DESCRIPTION
# 概要
パンくずリストの会社名を選択しても部が表示されないバグの修正

# 範囲
Department.javaのgetUsersメソッドを削除した

# 動作確認
部署に関する操作を行う