### PR TITLE
送信者の部署名を表示

### DIFF
--- a/src/main/java/com/example/sharing_service_site/entity/Message.java
+++ b/src/main/java/com/example/sharing_service_site/entity/Message.java
@@ -59,7 +59,6 @@ public class Message {
   public String getContent() { return content; }
   public LocalDateTime getCreatedAt() { return createdAt; }
   public LocalDateTime getUpdatedAt() { return updatedAt; }
-  public String getAuthorName() { return author.getFullName(); }
   public String getCreatedAtText() {return createdAt.toString()
                                                     .replace('T', ' ')
                                                     .substring(0, 16); }

--- a/src/main/resources/static/css/message.css
+++ b/src/main/resources/static/css/message.css
@@ -32,16 +32,20 @@
   align-items: center;
 }
 
-.message-name {
+.message-header-left {
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: bold;
   color: #495057;
 }
 
-.message-date {
+.message-header-right {
   font-size: 0.75rem;
   color: #adb5bd;
-  margin-left: 8px;
+}
+
+.message-department {
+  font-weight: normal;
+  color: #adb5bd;
 }
 
 .message-content {

--- a/src/main/resources/static/css/profile.css
+++ b/src/main/resources/static/css/profile.css
@@ -1,7 +1,7 @@
 .main-content h2 {
   text-align: center;
   font-size: 1.5rem;
-  font-weight: 600;
+  font-weight: bold;
   color: #007bff;
   background-color: #f0f8ff;
   padding: 1rem;
@@ -33,7 +33,7 @@
 }
 
 .profile-label {
-  font-weight: 600;
+  font-weight: bold;
   color: #555;
 }
 

--- a/src/main/resources/templates/message.html
+++ b/src/main/resources/templates/message.html
@@ -22,13 +22,27 @@
           部署名の掲示板
         </h1>
 
-        <ul class="message-list" th:classappend="${roleName != '閲覧のみ'} ? ' message-list' : ' message-list-viewer'">
+        <ul
+          class="message-list"
+          th:classappend="${roleName != '閲覧のみ'} ? ' message-list' : ' message-list-viewer'"
+        >
           <li class="message-card" th:each="msg : ${messages}">
             <div class="message-header">
-              <b class="message-name" th:text="${msg.authorName}">名前</b>
-              <span class="message-date" th:text="${msg.createdAtText}"
-                >日時</span
-              >
+              <dib class="message-header-left">
+                <b class="message-name" th:text="${msg.author.fullName}"
+                  >名前</b
+                >
+                <b
+                  class="message-department"
+                  th:text="'- ' + ${msg.author.department.departmentName}"
+                  >部署名</b
+                >
+              </dib>
+              <dib class="message-header-right">
+                <span class="message-date" th:text="${msg.createdAtText}"
+                  >日時</span
+                >
+              </dib>
             </div>
             <div class="message-content" th:text="${msg.content}">
               メッセージ
@@ -59,7 +73,6 @@
       </div>
     </div>
 
-    <script th:src="@{/js/message.js}"></script>
     <script th:src="@{/js/sidebar.js}"></script>
   </body>
 </html>


### PR DESCRIPTION
# 概要
メッセージ送信者の部署名を表示した

# 範囲
## やったこと
* 送信者の名前の横に部署名を表示した
* メッセージヘッダーを左右に分割して管理できるようにした
* MessageエンティティのgetAuthorNameメソッドはメッセージの機能を超越しているため削除し、massage.author.fullNameで取得する設計に変更した

## やっていないこと
* メッセージヘッダーの右側の調整

# 動作確認
メッセージページを表示して部署名が表示されていることを確認
<img width="1896" height="505" alt="image" src="https://github.com/user-attachments/assets/995e8805-99cc-4a3c-a46b-071b98fb6959" />

Issue: #43 