### PR TITLE
メッセージ削除機能実装

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/AuthController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/AuthController.java
@@ -73,6 +73,7 @@ public class AuthController {
                         @AuthenticationPrincipal CustomUserDetails userDetails,
                         @RequestParam Long departmentId) {
     model.addAttribute("fullName", userDetails.getFullName());
+    model.addAttribute("userId", userDetails.getUserId());
     model.addAttribute("roleName", userDetails.getRoleName());
     model.addAttribute("departmentId", departmentId);
 
@@ -107,24 +108,31 @@ public class AuthController {
   public String getMessage(Model model,
                           @AuthenticationPrincipal CustomUserDetails userDetails,
                           @ModelAttribute("departmentId") Long departmentId) {
-    if (departmentId == null) {
-      return "redirect:/home";
-    }
-    populateMessageModel(model, userDetails, departmentId);
-    return "message";
-  }
-
-  private void populateMessageModel(Model model, CustomUserDetails userDetails, Long departmentId) {
     model.addAttribute("fullName", userDetails.getFullName());
     model.addAttribute("departmentId", departmentId);
-
-    User user = userDetailsService.getUser(userDetails.getEmployeeNumber());
-    model.addAttribute("user", user);
+    model.addAttribute("userId", userDetails.getUserId());
+    model.addAttribute("roleName", userDetails.getRoleName());
 
     String departmentName = departmentService.getDepartmentNameById(departmentId);
     List<Message> messages = messageService.getMessagesByDepartmentId(departmentId);
     model.addAttribute("selectedDepartmentName", departmentName);
     model.addAttribute("messages", messages);
+    return "message";
+  }
+
+  @PostMapping("/message/delete")
+  public String deleteMessage(@RequestParam Long messageId,
+                              @RequestParam Long departmentId,
+                              RedirectAttributes redirectAttributes) {
+    try {
+      messageService.deleteMessage(messageId);
+      redirectAttributes.addFlashAttribute("success", "メッセージを削除しました。");
+    } catch (IllegalArgumentException ex) {
+      redirectAttributes.addFlashAttribute("error", ex.getMessage());
+    }
+
+    redirectAttributes.addFlashAttribute("departmentId", departmentId);
+    return "redirect:/message";
   }
 
   @GetMapping("/profile")

--- a/src/main/java/com/example/sharing_service_site/service/MessageService.java
+++ b/src/main/java/com/example/sharing_service_site/service/MessageService.java
@@ -45,4 +45,13 @@ public class MessageService {
     Message message = new Message(department, author, content);
     return messageRepository.save(message);
   }
+
+  /**
+   * メッセージを削除する
+   * 
+   * @param messageId メッセージID
+   */
+  public void deleteMessage(Long messageId) {
+    messageRepository.deleteById(messageId);
+  }
 }

--- a/src/main/resources/static/css/home.css
+++ b/src/main/resources/static/css/home.css
@@ -97,10 +97,13 @@
 }
 
 .department-card {
+  display: flex;
   background: #f0f8ff;
   border-radius: 8px;
   padding: 1.5rem;
   text-align: center;
+  justify-content: center;
+  align-items: center;
   font-weight: bold;
   cursor: pointer;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);

--- a/src/main/resources/static/css/message.css
+++ b/src/main/resources/static/css/message.css
@@ -17,6 +17,13 @@
 }
 
 .message-card {
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+}
+
+.message-body {
+  flex: 1;
   background: #f8f9fa;
   border-radius: 10px;
   padding: 8px 12px;
@@ -52,6 +59,28 @@
   font-size: 1rem;
   color: #212529;
   word-break: break-word;
+}
+
+.message-options {
+  display: flex;
+  align-items: end;
+  justify-content: center;
+  width: 24px;
+  flex-shrink: 0;
+}
+
+.delete-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  color: #adb5bd;
+  transition: color 0.2s, transform 0.1s;
+}
+
+.delete-button:hover {
+  color: #dc3545;
+  transform: scale(1.1);
 }
 
 .message-input-area {
@@ -103,4 +132,58 @@
 
 .message-form button:hover {
   background: #0056b3;
+}
+
+.confirm-dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 30;
+}
+
+.hidden {
+  display: none;
+}
+
+.confirm-box {
+  background: white;
+  padding: 20px 30px;
+  border-radius: 12px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+  text-align: center;
+  min-width: 280px;
+}
+
+.confirm-buttons {
+  margin-top: 15px;
+  display: flex;
+  justify-content: space-around;
+}
+
+.confirm-btn {
+  padding: 8px 20px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.confirm-btn.delete {
+  background-color: #e74c3c;
+  color: white;
+}
+
+.confirm-btn.cancel {
+  background-color: #bdc3c7;
+  color: black;
+}
+
+.confirm-btn:hover {
+  opacity: 0.9;
 }

--- a/src/main/resources/static/js/message.js
+++ b/src/main/resources/static/js/message.js
@@ -1,0 +1,33 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const dialog = document.getElementById("confirmDialog");
+  const confirmBtn = document.getElementById("confirmDelete");
+  const cancelBtn = document.getElementById("cancelDelete");
+
+  let targetForm = null;
+
+  document.querySelectorAll(".delete-form").forEach((form) => {
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      targetForm = form;
+      dialog.classList.remove("hidden");
+    });
+  });
+
+  confirmBtn.addEventListener("click", () => {
+    if (targetForm) targetForm.submit();
+    dialog.classList.add("hidden");
+    targetForm = null;
+  });
+
+  cancelBtn.addEventListener("click", () => {
+    dialog.classList.add("hidden");
+    targetForm = null;
+  });
+
+  dialog.addEventListener("click", (event) => {
+    if (event.target === dialog) {
+      dialog.classList.add("hidden");
+      targetForm = null;
+    }
+  });
+});

--- a/src/main/resources/templates/message.html
+++ b/src/main/resources/templates/message.html
@@ -27,25 +27,54 @@
           th:classappend="${roleName != '閲覧のみ'} ? ' message-list' : ' message-list-viewer'"
         >
           <li class="message-card" th:each="msg : ${messages}">
-            <div class="message-header">
-              <dib class="message-header-left">
-                <b class="message-name" th:text="${msg.author.fullName}"
-                  >名前</b
-                >
-                <b
-                  class="message-department"
-                  th:text="'- ' + ${msg.author.department.departmentName}"
-                  >部署名</b
-                >
-              </dib>
-              <dib class="message-header-right">
-                <span class="message-date" th:text="${msg.createdAtText}"
-                  >日時</span
-                >
-              </dib>
+            <div class="message-body">
+              <div class="message-header">
+                <dib class="message-header-left">
+                  <b class="message-name" th:text="${msg.author.fullName}"
+                    >名前</b
+                  >
+                  <b
+                    class="message-department"
+                    th:text="'- ' + ${msg.author.department.departmentName}"
+                    >部署名</b
+                  >
+                </dib>
+                <dib class="message-header-right">
+                  <span class="message-date" th:text="${msg.createdAtText}"
+                    >日時</span
+                  >
+                </dib>
+              </div>
+              <div class="message-content" th:text="${msg.content}">
+                メッセージ
+              </div>
             </div>
-            <div class="message-content" th:text="${msg.content}">
-              メッセージ
+            <div class="message-options">
+              <form
+                class="delete-form"
+                th:action="@{/message/delete}"
+                method="post"
+                th:if="${userId == msg.author.userId}"
+              >
+                <input
+                  type="hidden"
+                  th:name="${_csrf.parameterName}"
+                  th:value="${_csrf.token}"
+                />
+                <input
+                  type="hidden"
+                  name="messageId"
+                  th:value="${msg.messageId}"
+                />
+                <input
+                  type="hidden"
+                  name="departmentId"
+                  th:value="${departmentId}"
+                />
+                <button class="delete-button" type="submit" title="削除">
+                  🗑
+                </button>
+              </form>
             </div>
           </li>
         </ul>
@@ -73,6 +102,19 @@
       </div>
     </div>
 
+    <div class="confirm-dialog hidden" id="confirmDialog">
+      <div class="confirm-box">
+        <p>このメッセージを削除しますか？</p>
+        <div class="confirm-buttons">
+          <button class="confirm-btn delete" id="confirmDelete">削除</button>
+          <button class="confirm-btn cancel" id="cancelDelete">
+            キャンセル
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <script th:src="@{/js/message.js}"></script>
     <script th:src="@{/js/sidebar.js}"></script>
   </body>
 </html>


### PR DESCRIPTION
# 概要
メッセージを削除する機能の実装

# 範囲
## やったこと
* メッセージページで過去に自分が送信したメッセージを、権限に関わらず削除するボタンを実装
* 削除後は確認ダイアログが表示されて操作を要求する
* DBからも削除される
* メインページのフレックスなデザインの軽微な修正

## やってないこと
* 確認ダイアログのボタンをTabキーで操作できるようにする
* 確認ダイアログが表示されているときにTabキーでほかの操作ができることを防ぐ処理
* 削除するメッセージを確認ダイアログに表示してどのメッセージを削除するか明記する

# 動作確認
メッセージを送信したことのあるユーザーでメッセージ横のごみ箱ボタンを選択してメッセージを削除する

↓削除ボタンを押した直後
<img width="1817" height="782" alt="image" src="https://github.com/user-attachments/assets/dbb8b78c-6f02-4261-a470-dbc1a3c739dc" />

↓削除完了後
<img width="1817" height="779" alt="image" src="https://github.com/user-attachments/assets/c41045ad-0958-4400-8ad7-230896ddbe35" />

Issue: #41 