### PR TITLE
メッセージ編集機能実装

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/MessageController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/MessageController.java
@@ -84,6 +84,21 @@ public class MessageController {
     return "redirect:/message";
   }
 
+  @PostMapping("/message/edit")
+  public String editMessage(@RequestParam Long messageId,
+                            @RequestParam Long departmentId,
+                            @RequestParam String content,
+                            RedirectAttributes redirectAttributes) {
+    try {
+      messageService.updateMessage(messageId, content.trim());
+      redirectAttributes.addFlashAttribute("success", "メッセージを更新しました。");
+    } catch (IllegalArgumentException ex) {
+      redirectAttributes.addFlashAttribute("error", ex.getMessage());
+    }
+    redirectAttributes.addFlashAttribute("departmentId", departmentId);
+    return "redirect:/message";
+  }
+
   @PostMapping("/message/delete")
   public String deleteMessage(@RequestParam Long messageId,
                               @RequestParam Long departmentId,

--- a/src/main/java/com/example/sharing_service_site/entity/Message.java
+++ b/src/main/java/com/example/sharing_service_site/entity/Message.java
@@ -62,6 +62,10 @@ public class Message {
   public String getCreatedAtText() {return createdAt.toString()
                                                     .replace('T', ' ')
                                                     .substring(0, 16); }
+  public String getUpdatedAtText() {
+    return updatedAt != null ? updatedAt.toString()
+                                        .replace('T', ' ')
+                                        .substring(0, 16) : ""; }
 
   public void setDepartment(Department department) { this.department = department; }
   public void setAuthor(User author) { this.author = author; }

--- a/src/main/java/com/example/sharing_service_site/service/MessageService.java
+++ b/src/main/java/com/example/sharing_service_site/service/MessageService.java
@@ -47,6 +47,22 @@ public class MessageService {
   }
 
   /**
+   * メッセージを更新する
+   * 
+   * @param messageId メッセージID
+   * @param newContent 新しいメッセージ内容
+   * @return 更新されたメッセージ
+   * @throws IllegalArgumentException メッセージが見つからない場合
+   */
+  public Message updateMessage(Long messageId, String newContent) {
+    Message message = messageRepository.findById(messageId)
+        .orElseThrow(() -> new IllegalArgumentException("メッセージが見つかりません: " + messageId));
+    
+    message.updateContent(newContent);
+    return messageRepository.save(message);
+  }
+
+  /**
    * メッセージを削除する
    * 
    * @param messageId メッセージID

--- a/src/main/resources/static/css/message.css
+++ b/src/main/resources/static/css/message.css
@@ -45,30 +45,84 @@
   color: #495057;
 }
 
-.message-header-right {
-  font-size: 0.75rem;
-  color: #adb5bd;
-}
-
 .message-department {
   font-weight: normal;
   color: #adb5bd;
 }
 
-.message-content {
+.message-header-right {
+  font-size: 0.75rem;
+  color: #adb5bd;
+}
+
+.message-content-view {
   font-size: 1rem;
   color: #212529;
   word-break: break-word;
 }
 
+.message-content-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.edit-textarea {
+  resize: none;
+  height: 48px;
+  padding: 8px;
+  border: 1px solid #dee2e6;
+  border-radius: 6px;
+}
+
+.edit-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.save-button {
+  background: #007bff;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 16px;
+  color: white;
+  font-weight: bold;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.save-button:hover {
+  background: #0056b3;
+}
+
+.cancel-button {
+  background-color: #e0e0e0;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 16px;
+  color: black;
+  font-weight: bold;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.cancel-button:hover {
+  background-color: #c0c0c0;
+}
+
 .message-options {
   display: flex;
+  flex-direction: column;
   align-items: end;
-  justify-content: center;
+  justify-content: end;
   width: 24px;
   flex-shrink: 0;
 }
 
+.edit-button,
 .delete-button {
   background: none;
   border: none;
@@ -78,6 +132,7 @@
   transition: color 0.2s, transform 0.1s;
 }
 
+.edit-button:hover,
 .delete-button:hover {
   color: #dc3545;
   transform: scale(1.1);

--- a/src/main/resources/static/js/message.js
+++ b/src/main/resources/static/js/message.js
@@ -1,4 +1,86 @@
 document.addEventListener("DOMContentLoaded", () => {
+  let currentEditingCard = null;
+
+  document.addEventListener("click", (e) => {
+    const editBtn = e.target.closest(".edit-button");
+    if (editBtn) {
+      const card = editBtn.closest(".message-card");
+      toggleEditMode(card);
+    }
+
+    const saveBtn = e.target.closest(".save-button");
+    if (saveBtn) {
+      const card = saveBtn.closest(".message-card");
+      saveEdit(card);
+    }
+
+    const cancelBtn = e.target.closest(".cancel-button");
+    if (cancelBtn) {
+      const card = cancelBtn.closest(".message-card");
+      cancelEdit(card);
+    }
+  });
+
+  function toggleEditMode(card) {
+    if (currentEditingCard && currentEditingCard !== card) {
+      cancelEdit(currentEditingCard);
+    }
+
+    if (currentEditingCard === card) {
+      cancelEdit(card);
+      return;
+    }
+
+    enterEditMode(card);
+  }
+
+  function enterEditMode(card) {
+    if (currentEditingCard && currentEditingCard !== card) {
+      cancelEdit(currentEditingCard);
+    }
+
+    const view = card.querySelector(".message-content-view");
+    const edit = card.querySelector(".message-content-edit");
+    const textarea = edit.querySelector(".edit-textarea");
+
+    textarea.value = view.textContent.trim();
+    view.classList.add("hidden");
+    edit.classList.remove("hidden");
+    textarea.focus();
+
+    currentEditingCard = card;
+  }
+
+  function saveEdit(card) {
+    const view = card.querySelector(".message-content-view");
+    const edit = card.querySelector(".message-content-edit");
+    const textarea = edit.querySelector(".edit-textarea");
+
+    const newText = textarea.value.trim();
+    if (newText === "") {
+      alert("メッセージを空にはできません。");
+      return;
+    }
+
+    view.classList.remove("hidden");
+    edit.classList.add("hidden");
+
+    currentEditingCard = null;
+  }
+
+  function cancelEdit(card) {
+    const view = card.querySelector(".message-content-view");
+    const edit = card.querySelector(".message-content-edit");
+    view.classList.remove("hidden");
+    edit.classList.add("hidden");
+
+    if (currentEditingCard === card) {
+      currentEditingCard = null;
+    }
+  }
+});
+
+document.addEventListener("DOMContentLoaded", () => {
   const dialog = document.getElementById("confirmDialog");
   const confirmBtn = document.getElementById("confirmDelete");
   const cancelBtn = document.getElementById("cancelDelete");

--- a/src/main/resources/templates/message.html
+++ b/src/main/resources/templates/message.html
@@ -29,7 +29,7 @@
           <li class="message-card" th:each="msg : ${messages}">
             <div class="message-body">
               <div class="message-header">
-                <dib class="message-header-left">
+                <div class="message-header-left">
                   <b class="message-name" th:text="${msg.author.fullName}"
                     >名前</b
                   >
@@ -38,18 +38,66 @@
                     th:text="'- ' + ${msg.author.department.departmentName}"
                     >部署名</b
                   >
-                </dib>
-                <dib class="message-header-right">
-                  <span class="message-date" th:text="${msg.createdAtText}"
+                </div>
+                <div class="message-header-right">
+                  <span
+                    class="message-updated-date"
+                    th:text="${msg.updatedAtText} + ' (編集済み)'"
+                    th:if="${msg.edited}"
+                    >更新日時</span
+                  >
+                  <span
+                    class="message-date"
+                    th:text="${msg.createdAtText}"
+                    th:unless="${msg.edited}"
                     >日時</span
                   >
-                </dib>
+                </div>
               </div>
-              <div class="message-content" th:text="${msg.content}">
+
+              <div class="message-content-view" th:text="${msg.content}">
                 メッセージ
               </div>
+
+              <form
+                class="message-content-edit hidden"
+                th:action="@{/message/edit}"
+                method="post"
+              >
+                <input
+                  type="hidden"
+                  th:name="${_csrf.parameterName}"
+                  th:value="${_csrf.token}"
+                />
+                <input
+                  type="hidden"
+                  name="messageId"
+                  th:value="${msg.messageId}"
+                />
+                <input
+                  type="hidden"
+                  name="departmentId"
+                  th:value="${departmentId}"
+                />
+                <textarea class="edit-textarea" name="content"></textarea>
+
+                <div class="edit-buttons">
+                  <button type="submit" class="save-button">保存</button>
+                  <button type="button" class="cancel-button">
+                    キャンセル
+                  </button>
+                </div>
+              </form>
             </div>
             <div class="message-options">
+              <button
+                class="edit-button"
+                type="button"
+                title="編集"
+                th:if="${userId == msg.author.userId}"
+              >
+                🖊
+              </button>
               <form
                 class="delete-form"
                 th:action="@{/message/delete}"


### PR DESCRIPTION
# 概要
メッセージページで送信したメッセージの編集を可能にし、編集後はその日時と編集済みであることを表示した。

#範囲
## やったこと
* 編集ボタンを実装し、選択することでメッセージを直接編集することを可能にした
* 保存ボタンで変更を反映して、キャンセルボタンで編集を取り消す

## やっていないこと
* **編集済みのメッセージが最初に送信された日時(や内容)をツールチップなどで表示する**
* **変更されていないのに保存ボタンが押されたときに編集済みにならないような処理**
* メッセージを空にしたときの処理の統一
* 送信・編集・削除後に自動スクロール → #49 

# 動作確認
メッセージページで送信したメッセージを編集ボタンで編集する。

↓ 編集前
<img width="1214" height="201" alt="スクリーンショット 2025-10-11 050512" src="https://github.com/user-attachments/assets/b9e7ac9c-e60c-4c22-9f8e-d7f5fca8a4f8" />

↓ 編集中
<img width="1214" height="286" alt="スクリーンショット 2025-10-11 050554" src="https://github.com/user-attachments/assets/061fcdc4-eede-4f4c-9179-a81f3b01570e" />

↓ 編集後
<img width="1211" height="200" alt="スクリーンショット 2025-10-11 050608" src="https://github.com/user-attachments/assets/e9c7f022-80aa-492e-b315-ffde6e1a91e5" />


Issue: #42 