### PR TITLE
メッセージのスクロール実装

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/MessageController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/MessageController.java
@@ -81,6 +81,7 @@ public class MessageController {
       redirectAttributes.addFlashAttribute("error", ex.getMessage());
     }
     redirectAttributes.addFlashAttribute("departmentId", departmentId);
+    redirectAttributes.addFlashAttribute("scrollToEnd", true);
     return "redirect:/message";
   }
 
@@ -96,6 +97,7 @@ public class MessageController {
       redirectAttributes.addFlashAttribute("error", ex.getMessage());
     }
     redirectAttributes.addFlashAttribute("departmentId", departmentId);
+    redirectAttributes.addFlashAttribute("scrollToEnd", true);
     return "redirect:/message";
   }
 
@@ -110,6 +112,7 @@ public class MessageController {
       redirectAttributes.addFlashAttribute("error", ex.getMessage());
     }
     redirectAttributes.addFlashAttribute("departmentId", departmentId);
+    redirectAttributes.addFlashAttribute("scrollToEnd", true);
     return "redirect:/message";
   }
 }

--- a/src/main/resources/static/css/message.css
+++ b/src/main/resources/static/css/message.css
@@ -1,6 +1,5 @@
 .main-content {
-  margin-bottom: 90px;
-  padding-bottom: 24px;
+  padding-bottom: 114px;
 }
 
 .message-list {

--- a/src/main/resources/static/js/message.js
+++ b/src/main/resources/static/js/message.js
@@ -113,3 +113,14 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 });
+
+window.addEventListener("load", () => {
+  const container = document.getElementById("mainContent");
+  if (scrollToEnd) {
+    container.scrollIntoView({ behavior: "instant", block: "end" });
+  } else {
+    setTimeout(() => {
+      container.scrollIntoView({ behavior: "smooth", block: "end" });
+    }, 300);
+  }
+});

--- a/src/main/resources/templates/message.html
+++ b/src/main/resources/templates/message.html
@@ -158,6 +158,13 @@
       </div>
     </div>
 
+    <script th:inline="javascript">
+      /**
+       * @type {boolean}
+       * サーバー側から渡されたフラグ（true の場合のみスクロールする）
+       */
+      const scrollToEnd = /*[[${scrollToEnd}]]*/ false;
+    </script>
     <script th:src="@{/js/sidebar.js}"></script>
     <script th:src="@{/js/message.js}"></script>
   </body>


### PR DESCRIPTION
# 概要
メッセージページを開いたときに部署名を表示し、自動で最新のメッセージまでスクロールする

# 範囲
## やったこと
* メッセージページを開くとまずは通常表示したのち、デフォルトでは0.3秒待機したのち最新メッセージまでスクロールする
* メッセージの送信や編集、削除の際には即時スクロールされた状態にする
* HTMLでTypeScriptエンジンが型を理解できるようにJSDocコメントを記述

## やっていないこと
* 設定ページでページを開いた際のスクロール設定を行なえるようにする

# 動作確認
メッセージページを開く、送信・編集・削除を行い、それぞれの動作を確認する

↓ ページを開いたとき
<img width="1915" height="873" alt="image" src="https://github.com/user-attachments/assets/a96365e1-d6e9-48e4-b027-b389e3142a9a" />

↓ 0.3秒経った後
<img width="1915" height="874" alt="image" src="https://github.com/user-attachments/assets/4e43d989-1583-4201-82cb-77f4b5f1c05b" />

↓ 新規メッセージ送信後
<img width="1915" height="873" alt="image" src="https://github.com/user-attachments/assets/5567cd9b-9ef1-4a7e-9207-005a5ee90fb3" />

Issue: #49 