### PR TITLE
テキスト表示の仕様変更

### DIFF
--- a/src/main/resources/static/css/message.css
+++ b/src/main/resources/static/css/message.css
@@ -63,6 +63,7 @@
 .message-content-view {
   font-size: 1rem;
   color: #212529;
+  white-space: pre-wrap;
   word-break: break-word;
 }
 
@@ -74,7 +75,6 @@
 
 .edit-textarea {
   resize: none;
-  height: 48px;
   padding: 8px;
   border: 1px solid #dee2e6;
   border-radius: 6px;

--- a/src/main/resources/static/js/message.js
+++ b/src/main/resources/static/js/message.js
@@ -43,7 +43,12 @@ document.addEventListener("DOMContentLoaded", () => {
     const edit = card.querySelector(".message-content-edit");
     const textarea = edit.querySelector(".edit-textarea");
 
-    textarea.value = view.textContent.trim();
+    const originalText = view.textContent.trim();
+    textarea.value = originalText;
+
+    const lineCount = (originalText.match(/\n/g) || []).length + 1;
+    textarea.rows = Math.min(Math.max(lineCount, 2), 20) + 1;
+
     view.classList.add("hidden");
     edit.classList.remove("hidden");
     textarea.focus();


### PR DESCRIPTION
# 概要
* メッセージの改行が表示に反映されるようにする
* 編集のテキストエリアを分量に応じて調整する

# 範囲
## やったこと
* テキストの改行をcssで反映させた
* メッセージテキストの改行をjsで取得し、テキストエリアの長さに反映させた

## やっていないこと
* 編集中に行が変わった際にリアルタイムで反映させる

# 動作確認
メッセージページで複数行にまたがるメッセージを表示・編集して行を確認する

Issue: #53 