### PR TITLE
設定項目の変更可能

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/HomeController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/HomeController.java
@@ -1,6 +1,7 @@
 package com.example.sharing_service_site.controller;
 
 import java.util.List;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -11,14 +12,18 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import com.example.sharing_service_site.entity.Department;
 import com.example.sharing_service_site.service.CustomUserDetails;
 import com.example.sharing_service_site.service.DepartmentService;
+import com.example.sharing_service_site.service.SettingsService;
 
 @Controller
 public class HomeController {
 
   private final DepartmentService departmentService;
+  private final SettingsService settingsService;
 
-  public HomeController(DepartmentService departmentService) {
+  public HomeController(DepartmentService departmentService,
+                        SettingsService settingsService) {
     this.departmentService = departmentService;
+    this.settingsService = settingsService;
   }
 
   @GetMapping("/home")
@@ -31,6 +36,9 @@ public class HomeController {
     List<Department> rootDepartments =
         departmentService.getRootDepartmentsByCompany(userDetails.getCompany());
     model.addAttribute("departments", rootDepartments);
+
+    String themeColor = settingsService.getThemeColorByUserId(userDetails.getUserId());
+    model.addAttribute("themeColor", themeColor);
     return "home";
   }
 

--- a/src/main/java/com/example/sharing_service_site/controller/SettingsController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/SettingsController.java
@@ -30,10 +30,18 @@ public class SettingsController {
   @GetMapping("/settings")
   public String settings(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
     model.addAttribute("fullName", userDetails.getFullName());
-
     Settings settings = settingsService.getSettingsByUserId(userDetails.getUserId());
     model.addAttribute("settings", settings);
     return "/settings";
+  }
+
+  @PostMapping("/settings/updateThemeColor")
+  public String updateSettings(@AuthenticationPrincipal CustomUserDetails userDetails,
+                               @RequestParam String themeColor,
+                               RedirectAttributes redirectAttributes) {
+    settingsService.updateThemeColor(userDetails.getUserId(), themeColor);
+    redirectAttributes.addFlashAttribute("success", "設定を更新しました。");
+    return "redirect:/settings";
   }
 
   @GetMapping("/settings/user")

--- a/src/main/java/com/example/sharing_service_site/service/SettingsService.java
+++ b/src/main/java/com/example/sharing_service_site/service/SettingsService.java
@@ -33,4 +33,12 @@ public class SettingsService {
     settings.setThemeColor(themeColor);
     return settingsRepository.save(settings);
   }
+
+
+  // 以下、各種設定項目のゲッターを追加
+  public String getThemeColorByUserId(Long userId) {
+    Settings settings = settingsRepository.findByUserUserId(userId)
+        .orElseThrow(() -> new IllegalArgumentException("設定情報が存在しません: " + userId));
+    return settings.getThemeColor();
+  }
 }

--- a/src/main/resources/static/css/settings.css
+++ b/src/main/resources/static/css/settings.css
@@ -1,18 +1,60 @@
+.settings-card {
+  background-color: white;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-item {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid #e0e0e0;
+  white-space: nowrap;
+}
+
+.settings-item:last-child {
+  border-bottom: none;
+}
+
+.settings-label {
+  font-weight: bold;
+  color: #555;
+}
+
+.value {
+  color: #111;
+}
+
+.settings-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin: 1rem;
+}
+
 .settings-btn {
   background-color: #007bff;
   color: white;
+  padding: 0.6rem 1.2rem;
   border: none;
-  border-radius: 4px;
-  padding: 6px 10px;
-  cursor: pointer;
-  font-size: 0.9rem;
+  border-radius: 6px;
   text-decoration: none;
-  transition: background-color 0.2s ease;
+  font-weight: bold;
+  font-size: 1rem;
+  transition: background-color 0.2s ease, transform 0.1s ease;
   white-space: nowrap;
 }
 
 .settings-btn:hover {
   background-color: #0056b3;
+  transform: translateY(-2px);
+}
+
+.settings-btn:active {
+  transform: translateY(0);
 }
 
 .user-container {

--- a/src/main/resources/templates/settings.html
+++ b/src/main/resources/templates/settings.html
@@ -17,16 +17,74 @@
         <h1>設定</h1>
 
         <div class="settings-card">
-          <div class="settings-card">
-            <h2>ユーザー設定</h2>
+          <div class="settings-item">
+            <span class="settings-label">テーマカラー</span>
+            <form
+              class="theme-form"
+              th:action="@{/settings/updateThemeColor}"
+              method="post"
+            >
+              <input
+                type="hidden"
+                th:name="${_csrf.parameterName}"
+                th:value="${_csrf.token}"
+              />
+              <select
+                class="settings-select"
+                id="themeColorSelect"
+                name="themeColor"
+                th:value="${settings.themeColor}"
+              >
+                <option
+                  value="navy_blue"
+                  th:selected="${settings.themeColor == 'navy_blue'}"
+                >
+                  ネイビーブルー
+                </option>
+                <option
+                  value="dark_gray"
+                  th:selected="${settings.themeColor == 'dark_gray'}"
+                >
+                  ダークグレー
+                </option>
+                <option
+                  value="light"
+                  th:selected="${settings.themeColor == 'light'}"
+                >
+                  ライト
+                </option>
+                <option
+                  value="green"
+                  th:selected="${settings.themeColor == 'green'}"
+                >
+                  グリーン
+                </option>
+                <option
+                  value="pink"
+                  th:selected="${settings.themeColor == 'pink'}"
+                >
+                  ピンク
+                </option>
+              </select>
+              <button class="settings-btn" type="submit">変更</button>
+            </form>
+          </div>
 
-            <!-- 項目をテキストで表示 -->
-            <div th:each="setting : ${settings}">
-              <p>テーマカラー: <span th:text="${setting.themeColor}"></span></p>
-              <p>
-                部署の並び順: <span th:text="${setting.departmentOrder}"></span>
-              </p>
-            </div>
+          <div class="settings-item">
+            <span class="settings-label">部署の並び順</span>
+            <span class="value" th:text="${settings.departmentOrder}"
+              >部署の並び順</span
+            >
+          </div>
+
+          <div class="settings-item">
+            <span class="settings-label">サンプル</span>
+            <span class="value">サンプル</span>
+          </div>
+
+          <div class="settings-item">
+            <span class="settings-label">サンプル</span>
+            <span class="value">サンプル</span>
           </div>
 
           <div class="settings-actions" sec:authorize="hasRole('ADMIN')">


### PR DESCRIPTION
# 概要
設定項目を変更してDBの情報を書き換える

# 範囲
## やったこと
* 設定ページのテーマカラーのみプルダウンリスト作成(複数の選択肢を仮で表示)
* DBに設定内容を反映させる

## やっていないこと
* 変更したことが分かるような表示(トースト表示など)
* テーマカラー以外の設定項目の追加
* 変更した設定項目の反映
* テーマカラー変更用のCSSファイルの作成とクラスの整備
* 前頁に適応させるためのコントローラーの作成(@ControllerAdviceアノテーションを用いる)
* @AuthenticationPrincipal CustomUserDetails userDetailsに対しても同様にコントローラーの整備が必要

# 動作確認
設定ページで項目を変更後に変更ボタンを押して適応されていることを確認する

設定項目の変更前↓
<img width="1822" height="662" alt="image" src="https://github.com/user-attachments/assets/065a4ba4-3f62-4b04-85e2-93d2a7676e2e" />

設定項目の変更後↓
<img width="1819" height="665" alt="image" src="https://github.com/user-attachments/assets/4c681417-ffe7-4ace-b825-fbcb442b784a" />

Issue: #45 