### PR TITLE
ホーム画面の色設定実装

### DIFF
--- a/src/main/resources/static/css/color.css
+++ b/src/main/resources/static/css/color.css
@@ -1,0 +1,138 @@
+:root[themeColor="navy_blue"] {
+  /* ヘッダー */
+  --color-header-bg: #001f4d;
+  --color-header-text: #ffffff;
+  --color-button-header-bg: #001f4d;
+  --color-button-header-bg-hover: #ffffff;
+  --color-button-header-text: #ffffff;
+  --color-button-header-text-hover: #001f4d;
+  --color-button-header-border: #ffffff;
+
+  /* サイドバー */
+  --color-sidebar-bg: #000c1d;
+  --color-sidebar-bg-hover: #5a6168;
+  --color-sidebar-text: #ffffff;
+  --color-overlay: rgba(0, 0, 0, 0.5);
+
+  /* ホーム */
+  --color-breadcrumb-bg: #dbeeff;
+  --color-breadcrumb-bg-hover: #f0f8ff;
+  --color-breadcrumb-text: #000000;
+  --color-department-card-bg: #f0f8ff;
+  --color-department-card-bg-hover: #dbeeff;
+  --color-department-card-text: #000000;
+}
+
+:root[themeColor="dark_gray"] {
+  /* ヘッダー */
+  --color-header-bg: #2a2a2a;
+  --color-header-text: #ffffff;
+  --color-button-header-bg: #2a2a2a;
+  --color-button-header-bg-hover: #ffffff;
+  --color-button-header-text: #ffffff;
+  --color-button-header-text-hover: #2a2a2a;
+  --color-button-header-border: #ffffff;
+
+  /* サイドバー */
+  --color-sidebar-bg: #1a1a1a;
+  --color-sidebar-bg-hover: #555555;
+  --color-sidebar-text: #ffffff;
+  --color-overlay: rgba(0, 0, 0, 0.5);
+
+  /* ホーム */
+  --color-breadcrumb-bg: #cacaca;
+  --color-breadcrumb-bg-hover: #eaeaea;
+  --color-breadcrumb-text: #000000;
+  --color-department-card-bg: #eaeaea;
+  --color-department-card-bg-hover: #cacaca;
+  --color-department-card-text: #000000;
+}
+
+/* ヘッダー */
+header {
+  background-color: var(--color-header-bg);
+  color: var(--color-header-text);
+}
+
+.header-left a {
+  color: var(--color-header-text);
+}
+
+.logout-btn {
+  background-color: var(--color-button-header-bg);
+  color: var(--color-button-header-text);
+  border: 1px solid var(--color-button-header-border);
+}
+
+.logout-btn:hover {
+  background-color: var(--color-button-header-bg-hover);
+  color: var(--color-button-header-text-hover);
+}
+
+/* サイドバー */
+.sidebar {
+  background-color: var(--color-sidebar-bg);
+  color: var(--color-sidebar-text);
+}
+
+.sidebar a {
+  color: var(--color-sidebar-text);
+}
+
+.sidebar a:hover {
+  background-color: var(--color-sidebar-bg-hover);
+}
+
+.toggle-btn {
+  background: none;
+  border: none;
+  color: var(--color-sidebar-text);
+}
+
+.overlay {
+  background-color: var(--color-overlay);
+}
+
+/* ホーム */
+.message-btn {
+  color: #000000;
+  background: #ffffff;
+  border: 1px solid #ccc;
+}
+
+.message-btn:hover {
+  background: #eee;
+}
+
+.breadcrumb span {
+  background-color: transparent;
+  color: var(--color-breadcrumb-text);
+}
+
+.breadcrumb span.breadcrumb-link:hover::before,
+.breadcrumb span.breadcrumb-link:hover::after {
+  background-color: var(--color-breadcrumb-bg-hover);
+}
+
+.breadcrumb:has(span.breadcrumb-company:hover)::before {
+  background-color: var(--color-breadcrumb-bg-hover);
+}
+
+.breadcrumb span::before,
+.breadcrumb span::after {
+  background-color: var(--color-breadcrumb-bg);
+}
+
+.breadcrumb::before {
+  background-color: var(--color-breadcrumb-bg);
+}
+
+.department-card {
+  background-color: var(--color-department-card-bg);
+  color: var(--color-department-card-text);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.department-card:hover {
+  background-color: var(--color-department-card-bg-hover);
+}

--- a/src/main/resources/static/css/header.css
+++ b/src/main/resources/static/css/header.css
@@ -6,8 +6,6 @@ body {
 header {
   position: fixed;
   height: 60px;
-  background-color: #001f4d;
-  color: white;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -21,7 +19,6 @@ header {
 
 .header-left a {
   text-decoration: none;
-  color: white;
   font-size: 1.4rem;
   font-weight: bold;
   font-family: "Segoe UI", sans-serif;
@@ -39,14 +36,27 @@ header {
 }
 
 .logout-btn {
-  background-color: transparent;
-  border: 1px solid white;
   border-radius: 4px;
   padding: 0.4rem 0.8rem;
-  color: white;
   font-size: 0.9rem;
   cursor: pointer;
   transition: background-color 0.2s, color 0.2s;
+}
+
+/* 以下のデフォルトカラーは色設定変更完了後に削除する */
+header {
+  background-color: #001f4d;
+  color: white;
+}
+
+.header-left a {
+  color: white;
+}
+
+.logout-btn {
+  background-color: transparent;
+  border: 1px solid white;
+  color: white;
 }
 
 .logout-btn:hover {

--- a/src/main/resources/static/css/home.css
+++ b/src/main/resources/static/css/home.css
@@ -7,15 +7,12 @@
   display: inline-block;
   padding: 0.3rem 0.8rem 0.5rem;
   margin-left: 2rem;
-  border: 1px solid #ccc;
   border-radius: 6px;
   text-decoration: none;
-  color: black;
-  background: white;
   font-size: 2rem;
 }
+
 .message-btn:hover {
-  background: #eee;
   transform: translateY(-2px);
   transition: background-color 0.2s ease, transform 0.1s ease;
 }
@@ -35,11 +32,9 @@
 }
 
 .breadcrumb span {
-  color: black;
   position: relative;
   padding: 0.5rem 1.5rem 0.5rem 0.8rem;
   border-radius: 0.2rem;
-  background: transparent;
   white-space: nowrap;
 }
 
@@ -49,12 +44,10 @@
 
 .breadcrumb span.breadcrumb-link:hover::before,
 .breadcrumb span.breadcrumb-link:hover::after {
-  background: #f0f8ff;
   transition: background-color 0.2s ease;
 }
 
 .breadcrumb:has(span.breadcrumb-company:hover)::before {
-  background: #f0f8ff;
   transition: background-color 0.2s ease;
 }
 
@@ -65,7 +58,6 @@
   width: 100%;
   height: 50%;
   margin-left: 0.5rem;
-  background: #dbeeff;
   content: "";
   z-index: -5;
 }
@@ -87,7 +79,6 @@
   top: 0;
   bottom: 0;
   width: 1.5rem;
-  background: #dbeeff;
   pointer-events: none;
 }
 
@@ -99,7 +90,6 @@
 
 .department-card {
   display: flex;
-  background: #f0f8ff;
   border-radius: 8px;
   padding: 1.5rem;
   text-align: center;
@@ -107,8 +97,46 @@
   align-items: center;
   font-weight: bold;
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
   transition: background-color 0.2s ease;
+}
+
+/* 以下のデフォルトカラーは色設定変更完了後に削除する */
+.message-btn {
+  border: 1px solid #ccc;
+  color: black;
+  background: white;
+}
+
+.message-btn:hover {
+  background: #eee;
+}
+
+.breadcrumb span {
+  color: black;
+  background: transparent;
+}
+
+.breadcrumb span.breadcrumb-link:hover::before,
+.breadcrumb span.breadcrumb-link:hover::after {
+  background: #f0f8ff;
+}
+
+.breadcrumb:has(span.breadcrumb-company:hover)::before {
+  background: #f0f8ff;
+}
+
+.breadcrumb span::before,
+.breadcrumb span::after {
+  background: #dbeeff;
+}
+
+.breadcrumb::before {
+  background: #dbeeff;
+}
+
+.department-card {
+  background: #f0f8ff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
 .department-card:hover {

--- a/src/main/resources/static/css/sidebar.css
+++ b/src/main/resources/static/css/sidebar.css
@@ -9,8 +9,6 @@
   position: fixed;
   margin-top: 60px;
   width: 60px;
-  background-color: #000c1d;
-  color: white;
   transition: width 0.3s ease;
   overflow-x: hidden;
   height: 100vh;
@@ -26,9 +24,6 @@
   width: 60px;
   margin: 1rem 0;
   padding: 0;
-  background: none;
-  border: none;
-  color: white;
   font-size: 1.5rem;
   cursor: pointer;
 }
@@ -44,12 +39,7 @@
   align-items: center;
   padding: 0.8rem;
   text-decoration: none;
-  color: white;
   transition: background-color 0.2s;
-}
-
-.sidebar a:hover {
-  background-color: #5a6168;
 }
 
 .label {
@@ -93,7 +83,6 @@
   position: fixed;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
   opacity: 0;
   visibility: hidden;
   transition: opacity 0.3s ease;
@@ -103,4 +92,28 @@
 .overlay.active {
   opacity: 1;
   visibility: visible;
+}
+
+/* 以下のデフォルトカラーは色設定変更完了後に削除する */
+.sidebar {
+  background-color: #000c1d;
+  color: white;
+}
+
+.toggle-btn {
+  background: none;
+  border: none;
+  color: white;
+}
+
+.sidebar a {
+  color: white;
+}
+
+.sidebar a:hover {
+  background-color: #5a6168;
+}
+
+.overlay {
+  background-color: rgba(0, 0, 0, 0.5);
 }

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:attr="themeColor=${themeColor}">
   <head>
     <meta charset="UTF-8" />
     <title>Sharing Service Site</title>
     <link rel="stylesheet" th:href="@{/css/header.css}" />
     <link rel="stylesheet" th:href="@{/css/sidebar.css}" />
     <link rel="stylesheet" th:href="@{/css/home.css}" />
+    <link rel="stylesheet" th:href="@{/css/color.css}" />
   </head>
   <body>
     <div th:replace="fragments/header :: header(${fullName})"></div>

--- a/src/main/resources/templates/settings.html
+++ b/src/main/resources/templates/settings.html
@@ -47,24 +47,6 @@
                 >
                   ダークグレー
                 </option>
-                <option
-                  value="light"
-                  th:selected="${settings.themeColor == 'light'}"
-                >
-                  ライト
-                </option>
-                <option
-                  value="green"
-                  th:selected="${settings.themeColor == 'green'}"
-                >
-                  グリーン
-                </option>
-                <option
-                  value="pink"
-                  th:selected="${settings.themeColor == 'pink'}"
-                >
-                  ピンク
-                </option>
               </select>
               <button class="settings-btn" type="submit">変更</button>
             </form>


### PR DESCRIPTION
# 概要
テーマカラー設定をホーム画面に適応する

# 範囲
## やったこと
ホーム画面とそのヘッダー・サイドバーのみで、その他のページはデフォルトのネイビーブルーで表示される

## やっていないこと
* ホーム画面以外のcolor.cssの読み込み
* 背景色の変更機能実装はやっていないので、完全なダークモードのようにするには、ホームのbackground-colorに関する項目を追加して変更する

# 動作確認
設定ページから色を選択して変更し、ホーム画面を確認する。

↓色変更前 (ネイビーブルー)
<img width="1917" height="439" alt="image" src="https://github.com/user-attachments/assets/a80b37f2-4370-4ddf-b48a-318391b13a5a" />

↓色変更後 (ダークグレー)
<img width="1916" height="447" alt="image" src="https://github.com/user-attachments/assets/b0772845-fadf-46c2-86dd-cadf9f25f019" />

# 関連
## 別ページの実装方法
1. コントローラーに以下のコードがなければ追加してthemeColorを受け渡す
`String themeColor = settingsService.getThemeColorByUserId(userDetails.getUserId());
model.addAttribute("themeColor", themeColor);`
2. 実装するページのhtmlタグに`th:attr="themeColor=${themeColor}"`を追加する
3. 同様にheadタグに`<link rel="stylesheet" th:href="@{/css/color.css}" />`を追加する
4. color.cssの`:root[themeColor="navy_blue"] {}`内に要素名が分かるように続けて記述する
5. 実装ページのCSSから色の部分を取り出してcolor.cssに続けて記述する
6. 実装ページのCSSの色の部分をまとめて最後に記述し、完了後に削除しやすくする

↑基本的にはホーム画面の実装をまねるようにするとよい。

## テーマカラーの追加方法
1. settings.htmlに追加するテーマカラー用のoptionタグを追加する
2. color.cssに`:root[themeColor="〇〇"] {}`と追加してほかの色と同様に色を設定する

Issue: #57 