### PR TITLE
メッセージ画面の色設定実装

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/MessageController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/MessageController.java
@@ -17,6 +17,7 @@ import com.example.sharing_service_site.service.CustomUserDetails;
 import com.example.sharing_service_site.service.CustomUserDetailsService;
 import com.example.sharing_service_site.service.DepartmentService;
 import com.example.sharing_service_site.service.MessageService;
+import com.example.sharing_service_site.service.SettingsService;
 
 @Controller
 public class MessageController {
@@ -24,13 +25,16 @@ public class MessageController {
   private final MessageService messageService;
   private final DepartmentService departmentService;
   private final CustomUserDetailsService userDetailsService;
+  private final SettingsService settingsService;
 
   public MessageController(MessageService messageService,
                            DepartmentService departmentService,
-                           CustomUserDetailsService userDetailsService) {
+                           CustomUserDetailsService userDetailsService,
+                           SettingsService settingsService) {
     this.messageService = messageService;
     this.departmentService = departmentService;
     this.userDetailsService = userDetailsService;
+    this.settingsService = settingsService;
   }
 
   @PostMapping("/message")
@@ -49,6 +53,9 @@ public class MessageController {
     List<Message> messages = messageService.getMessagesByDepartmentId(departmentId);
     model.addAttribute("selectedDepartmentName", departmentName);
     model.addAttribute("messages", messages);
+
+    String themeColor = settingsService.getThemeColorByUserId(userDetails.getUserId());
+    model.addAttribute("themeColor", themeColor);
     return "message";
   }
 
@@ -65,6 +72,9 @@ public class MessageController {
     List<Message> messages = messageService.getMessagesByDepartmentId(departmentId);
     model.addAttribute("selectedDepartmentName", departmentName);
     model.addAttribute("messages", messages);
+
+    String themeColor = settingsService.getThemeColorByUserId(userDetails.getUserId());
+    model.addAttribute("themeColor", themeColor);
     return "message";
   }
 

--- a/src/main/resources/static/css/color.css
+++ b/src/main/resources/static/css/color.css
@@ -18,9 +18,35 @@
   --color-breadcrumb-bg: #dbeeff;
   --color-breadcrumb-bg-hover: #f0f8ff;
   --color-breadcrumb-text: #000000;
+  --color-button-message-bg: #ffffff;
+  --color-button-message-bg-hover: #eee;
+  --color-button-message-text: #000000;
   --color-department-card-bg: #f0f8ff;
   --color-department-card-bg-hover: #dbeeff;
   --color-department-card-text: #000000;
+
+  /* メッセージ */
+  --color-message-body-bg: #f8f9fa;
+  --color-message-body-name: #495057;
+  --color-message-body-header: #adb5bd;
+  --color-message-body-text: #212529;
+  --color-button-option: #adb5bd;
+  --color-button-option-hover: #dc3545;
+  --color-dialog-bg: #ffffff;
+  --color-dialog-text: #000000;
+
+  /* 共通 */
+  --color-bg: #ffffff;
+  --color-text: #000000;
+  --color-button-confirm: #007bff;
+  --color-button-confirm-hover: #0056b3;
+  --color-button-confirm-text: #ffffff;
+  --color-button-delete: #e74c3c;
+  --color-button-delete-hover: #c0392b;
+  --color-button-delete-text: #ffffff;
+  --color-button-cancel: #bdc3c7;
+  --color-button-cancel-hover: #c0c0c0;
+  --color-button-cancel-text: #000000;
 }
 
 :root[themeColor="dark_gray"] {
@@ -43,9 +69,35 @@
   --color-breadcrumb-bg: #cacaca;
   --color-breadcrumb-bg-hover: #eaeaea;
   --color-breadcrumb-text: #000000;
+  --color-button-message-bg: #ffffff;
+  --color-button-message-bg-hover: #eee;
+  --color-button-message-text: #000000;
   --color-department-card-bg: #eaeaea;
   --color-department-card-bg-hover: #cacaca;
   --color-department-card-text: #000000;
+
+  /* メッセージ */
+  --color-message-body-bg: #f8f9fa;
+  --color-message-body-name: #495057;
+  --color-message-body-header: #adb5bd;
+  --color-message-body-text: #212529;
+  --color-button-option: #adb5bd;
+  --color-button-option-hover: #dc3545;
+  --color-dialog-bg: #ffffff;
+  --color-dialog-text: #000000;
+
+  /* 共通 */
+  --color-bg: #ffffff;
+  --color-text: #000000;
+  --color-button-confirm: #2a2a2a;
+  --color-button-confirm-hover: #1a1a1a;
+  --color-button-confirm-text: #ffffff;
+  --color-button-delete: #e74c3c;
+  --color-button-delete-hover: #c0392b;
+  --color-button-delete-text: #ffffff;
+  --color-button-cancel: #bdc3c7;
+  --color-button-cancel-hover: #c0c0c0;
+  --color-button-cancel-text: #000000;
 }
 
 /* ヘッダー */
@@ -84,8 +136,6 @@ header {
 }
 
 .toggle-btn {
-  background: none;
-  border: none;
   color: var(--color-sidebar-text);
 }
 
@@ -94,14 +144,22 @@ header {
 }
 
 /* ホーム */
+body {
+  background-color: var(--color-bg);
+}
+
+.company-title {
+  color: var(--color-text);
+}
+
 .message-btn {
-  color: #000000;
-  background: #ffffff;
+  background-color: var(--color-button-message-bg);
+  color: var(--color-button-message-text);
   border: 1px solid #ccc;
 }
 
 .message-btn:hover {
-  background: #eee;
+  background-color: var(--color-button-message-bg-hover);
 }
 
 .breadcrumb span {
@@ -135,4 +193,113 @@ header {
 
 .department-card:hover {
   background-color: var(--color-department-card-bg-hover);
+}
+
+/* メッセージ */
+.body {
+  background-color: var(--color-bg);
+}
+
+.department-title {
+  color: var(--color-text);
+}
+
+.message-body {
+  background-color: var(--color-message-body-bg);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.message-header-left {
+  color: var(--color-message-body-name);
+}
+
+.message-department .message-header-right {
+  color: var(--color-message-body-header);
+}
+
+.message-content-view {
+  color: var(--color-message-body-text);
+}
+
+.edit-textarea {
+  border: 1px solid #dee2e6;
+}
+
+.save-btn {
+  background-color: var(--color-button-confirm);
+  color: var(--color-button-confirm-text);
+}
+
+.save-btn:hover {
+  background-color: var(--color-button-confirm-hover);
+}
+
+.cancel-btn {
+  background-color: var(--color-button-cancel);
+  color: var(--color-button-cancel-text);
+}
+
+.cancel-btn:hover {
+  background-color: var(--color-button-cancel-hover);
+}
+
+.edit-btn,
+.delete-btn {
+  color: var(--color-button-option);
+}
+
+.edit-btn:hover,
+.delete-btn:hover {
+  color: var(--color-button-option-hover);
+}
+
+.message-input-area {
+  background-color: var(--color-bg);
+  border-top: 1px solid #dee2e6;
+}
+
+.message-form textarea {
+  border: 1px solid #dee2e6;
+}
+
+.message-form textarea:focus {
+  border-color: #007bff;
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+}
+
+.message-form button {
+  background-color: var(--color-button-confirm);
+  color: var(--color-button-confirm-text);
+}
+
+.message-form button:hover {
+  background-color: var(--color-button-confirm-hover);
+}
+
+.confirm-dialog {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.confirm-box {
+  background-color: var(--color-dialog-bg);
+  color: var(--color-dialog-text);
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+}
+
+.confirm-btn.delete {
+  background-color: var(--color-button-delete);
+  color: var(--color-button-delete-text);
+}
+
+.confirm-btn.delete:hover {
+  background-color: var(--color-button-delete-hover);
+}
+
+.confirm-btn.cancel {
+  background-color: var(--color-button-cancel);
+  color: var(--color-button-cancel-text);
+}
+
+.confirm-btn.cancel:hover {
+  background-color: var(--color-button-cancel-hover);
 }

--- a/src/main/resources/static/css/home.css
+++ b/src/main/resources/static/css/home.css
@@ -104,41 +104,41 @@
 .message-btn {
   border: 1px solid #ccc;
   color: black;
-  background: white;
+  background-color: white;
 }
 
 .message-btn:hover {
-  background: #eee;
+  background-color: #eee;
 }
 
 .breadcrumb span {
   color: black;
-  background: transparent;
+  background-color: transparent;
 }
 
 .breadcrumb span.breadcrumb-link:hover::before,
 .breadcrumb span.breadcrumb-link:hover::after {
-  background: #f0f8ff;
+  background-color: #f0f8ff;
 }
 
 .breadcrumb:has(span.breadcrumb-company:hover)::before {
-  background: #f0f8ff;
+  background-color: #f0f8ff;
 }
 
 .breadcrumb span::before,
 .breadcrumb span::after {
-  background: #dbeeff;
+  background-color: #dbeeff;
 }
 
 .breadcrumb::before {
-  background: #dbeeff;
+  background-color: #dbeeff;
 }
 
 .department-card {
-  background: #f0f8ff;
+  background-color: #f0f8ff;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
 .department-card:hover {
-  background: #dbeeff;
+  background-color: #dbeeff;
 }

--- a/src/main/resources/static/css/message.css
+++ b/src/main/resources/static/css/message.css
@@ -28,13 +28,11 @@
 
 .message-body {
   flex: 1;
-  background: #f8f9fa;
   border-radius: 10px;
   padding: 8px 12px;
   display: flex;
   flex-direction: column;
   gap: 4px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
 .message-header {
@@ -47,22 +45,18 @@
 .message-header-left {
   font-size: 0.85rem;
   font-weight: bold;
-  color: #495057;
 }
 
 .message-department {
   font-weight: normal;
-  color: #adb5bd;
 }
 
 .message-header-right {
   font-size: 0.75rem;
-  color: #adb5bd;
 }
 
 .message-content-view {
   font-size: 1rem;
-  color: #212529;
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -76,7 +70,6 @@
 .edit-textarea {
   resize: none;
   padding: 8px;
-  border: 1px solid #dee2e6;
   border-radius: 6px;
 }
 
@@ -87,35 +80,23 @@
 }
 
 .save-btn {
-  background: #007bff;
   border: none;
   border-radius: 8px;
   padding: 8px 16px;
-  color: white;
   font-weight: bold;
   font-size: 1rem;
   cursor: pointer;
   transition: background-color 0.2s ease;
-}
-
-.save-btn:hover {
-  background: #0056b3;
 }
 
 .cancel-btn {
-  background-color: #e0e0e0;
   border: none;
   border-radius: 8px;
   padding: 8px 16px;
-  color: black;
   font-weight: bold;
   font-size: 1rem;
   cursor: pointer;
   transition: background-color 0.2s ease;
-}
-
-.cancel-btn:hover {
-  background-color: #c0c0c0;
 }
 
 .message-options {
@@ -133,13 +114,11 @@
   border: none;
   cursor: pointer;
   font-size: 1rem;
-  color: #adb5bd;
   transition: color 0.2s, transform 0.1s;
 }
 
 .edit-btn:hover,
 .delete-btn:hover {
-  color: #dc3545;
   transform: scale(1.1);
 }
 
@@ -148,8 +127,6 @@
   bottom: 0;
   left: 60px;
   right: 0;
-  background: white;
-  border-top: 1px solid #dee2e6;
   padding: 10px 20px;
   display: flex;
   justify-content: center;
@@ -168,32 +145,20 @@
   max-height: 120px;
   resize: none;
   padding: 8px;
-  border: 1px solid #dee2e6;
   border-radius: 8px;
   font-size: 1rem;
   outline: none;
 }
 
-.message-form textarea:focus {
-  border-color: #007bff;
-  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
-}
-
 .message-form button {
-  background: #007bff;
   border: none;
   border-radius: 8px;
   padding: 0 16px;
-  color: white;
   font-weight: bold;
   font-size: 1rem;
   cursor: pointer;
   transition: background-color 0.2s ease;
   white-space: nowrap;
-}
-
-.message-form button:hover {
-  background: #0056b3;
 }
 
 .confirm-dialog {
@@ -202,7 +167,6 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.5);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -214,10 +178,8 @@
 }
 
 .confirm-box {
-  background: white;
   padding: 20px 30px;
   border-radius: 12px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
   text-align: center;
   min-width: 280px;
 }
@@ -236,6 +198,95 @@
   font-size: 14px;
 }
 
+.confirm-btn:hover {
+  opacity: 0.9;
+}
+
+/* 以下のデフォルトカラーは色設定変更完了後に削除する */
+.message-body {
+  background-color: #f8f9fa;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.message-header-left {
+  color: #495057;
+}
+
+.message-department {
+  color: #adb5bd;
+}
+
+.message-header-right {
+  color: #adb5bd;
+}
+
+.message-content-view {
+  color: #212529;
+}
+
+.edit-textarea {
+  border: 1px solid #dee2e6;
+}
+
+.save-btn {
+  background-color: #007bff;
+  color: white;
+}
+
+.save-btn:hover {
+  background-color: #0056b3;
+}
+
+.cancel-btn {
+  background-color: #e0e0e0;
+  color: black;
+}
+
+.cancel-btn:hover {
+  background-color: #c0c0c0;
+}
+
+.edit-btn,
+.delete-btn {
+  color: #adb5bd;
+}
+
+.edit-btn:hover,
+.delete-btn:hover {
+  color: #dc3545;
+}
+
+.message-input-area {
+  background-color: white;
+  border-top: 1px solid #dee2e6;
+}
+.message-form textarea {
+  border: 1px solid #dee2e6;
+}
+
+.message-form textarea:focus {
+  border-color: #007bff;
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+}
+
+.message-form button {
+  background-color: #007bff;
+  color: white;
+}
+
+.message-form button:hover {
+  background-color: #0056b3;
+}
+
+.confirm-dialog {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.confirm-box {
+  background-color: white;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+}
+
 .confirm-btn.delete {
   background-color: #e74c3c;
   color: white;
@@ -244,8 +295,4 @@
 .confirm-btn.cancel {
   background-color: #bdc3c7;
   color: black;
-}
-
-.confirm-btn:hover {
-  opacity: 0.9;
 }

--- a/src/main/resources/static/css/settings.css
+++ b/src/main/resources/static/css/settings.css
@@ -117,7 +117,7 @@
   position: fixed;
   bottom: 20px;
   right: 20px;
-  background: #333;
+  background-color: #333;
   color: #fff;
   padding: 12px 20px;
   border-radius: 6px;

--- a/src/main/resources/static/css/sidebar.css
+++ b/src/main/resources/static/css/sidebar.css
@@ -25,6 +25,8 @@
   margin: 1rem 0;
   padding: 0;
   font-size: 1.5rem;
+  background: none;
+  border: none;
   cursor: pointer;
 }
 
@@ -101,8 +103,6 @@
 }
 
 .toggle-btn {
-  background: none;
-  border: none;
   color: white;
 }
 

--- a/src/main/resources/templates/message.html
+++ b/src/main/resources/templates/message.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:attr="themeColor=${themeColor}">
   <head>
     <meta charset="UTF-8" />
     <title>Sharing Service Site</title>
     <link rel="stylesheet" th:href="@{/css/header.css}" />
     <link rel="stylesheet" th:href="@{/css/sidebar.css}" />
     <link rel="stylesheet" th:href="@{/css/message.css}" />
+    <link rel="stylesheet" th:href="@{/css/color.css}" />
   </head>
   <body>
     <div th:replace="fragments/header :: header(${fullName})"></div>

--- a/src/main/resources/templates/settings.html
+++ b/src/main/resources/templates/settings.html
@@ -47,6 +47,12 @@
                 >
                   ダークグレー
                 </option>
+                <option
+                  value="not_exist"
+                  th:selected="${settings.themeColor == 'not_exist'}"
+                >
+                  存在しない色
+                </option>
               </select>
               <button class="settings-btn" type="submit">変更</button>
             </form>


### PR DESCRIPTION
# 概要
テーマカラー設定をメッセージ画面に適応する

# 範囲
## やったこと
* メッセージページの色設定を可能にした
* 背景色やテキストを一貫して変更できるように共通要素をしてまとめた
* テスト用として、設定できる色に「存在しない色」を追加した

## やっていないこと
ホーム画面とメッセージ画面以外の実装
メッセージの送信フォームと編集フォームでフォーカス時に**枠線の表示が異なる**が、原因が分からないので**修正していない**

# 動作確認
ホーム画面の実装と同様 #58 

↓色変更前(ネイビーブルー)
<img width="1914" height="875" alt="image" src="https://github.com/user-attachments/assets/3b581ee3-8e0b-4359-bd77-38c3bce82b62" />

↓色変更後 (ダークグレー)
<img width="1916" height="871" alt="image" src="https://github.com/user-attachments/assets/1e70d482-9bb8-4ed9-9a25-a56065e51112" />
<img width="1894" height="870" alt="image" src="https://github.com/user-attachments/assets/8a383fac-b224-4943-a54b-a9fb1f60ae7a" />

Issue: #57 