### PR TITLE
プロフィール画面の色設定実装

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/ProfileController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/ProfileController.java
@@ -2,6 +2,7 @@ package com.example.sharing_service_site.controller;
 
 import com.example.sharing_service_site.service.CustomUserDetails;
 import com.example.sharing_service_site.service.CustomUserDetailsService;
+import com.example.sharing_service_site.service.SettingsService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Controller;
@@ -13,11 +14,14 @@ public class ProfileController {
 
   private final BCryptPasswordEncoder passwordEncoder;
   private final CustomUserDetailsService userDetailsService;
+  private final SettingsService settingsService;
 
   public ProfileController(BCryptPasswordEncoder passwordEncoder,
-                           CustomUserDetailsService userDetailsService) {
+                           CustomUserDetailsService userDetailsService,
+                           SettingsService settingsService) {
     this.passwordEncoder = passwordEncoder;
     this.userDetailsService = userDetailsService;
+    this.settingsService = settingsService;
   }
 
   @GetMapping("/profile")
@@ -27,6 +31,9 @@ public class ProfileController {
     model.addAttribute("role", userDetails.getRoleName());
     model.addAttribute("company", userDetails.getCompanyName());
     model.addAttribute("department", userDetails.getDepartmentName());
+
+    String themeColor = settingsService.getThemeColorByUserId(userDetails.getUserId());
+    model.addAttribute("themeColor", themeColor);
     return "/profile";
   }
 
@@ -34,12 +41,18 @@ public class ProfileController {
   public String profileEdit(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
     model.addAttribute("fullName", userDetails.getFullName());
     model.addAttribute("password", userDetails.getPassword());
+
+    String themeColor = settingsService.getThemeColorByUserId(userDetails.getUserId());
+    model.addAttribute("themeColor", themeColor);
     return "/profile-edit";
   }
 
   @GetMapping("/profile/edit/done")
   public String profileEditDone(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
     model.addAttribute("fullName", userDetails.getFullName());
+
+    String themeColor = settingsService.getThemeColorByUserId(userDetails.getUserId());
+    model.addAttribute("themeColor", themeColor);
     return "/profile-edit-done";
   }
 
@@ -73,11 +86,17 @@ public class ProfileController {
 
     if (hasError) {
       model.addAttribute("fullName", userDetails.getFullName());
+      
+      String themeColor = settingsService.getThemeColorByUserId(userDetails.getUserId());
+      model.addAttribute("themeColor", themeColor);
       return "/profile-edit";
     }
 
     String encodedPassword = passwordEncoder.encode(newPassword);
     userDetailsService.updatePassword(userDetails.getUsername(), encodedPassword);
+
+    String themeColor = settingsService.getThemeColorByUserId(userDetails.getUserId());
+    model.addAttribute("themeColor", themeColor);
     return "redirect:/profile/edit/done";
   }
 }

--- a/src/main/resources/static/css/color.css
+++ b/src/main/resources/static/css/color.css
@@ -35,9 +35,14 @@
   --color-dialog-bg: #ffffff;
   --color-dialog-text: #000000;
 
+  /* プロフィール */
+  --color-message-profile-bg: #f0f8ff;
+  --color-message-profile-text: #007bff;
+
   /* 共通 */
   --color-bg: #ffffff;
   --color-text: #000000;
+  --color-text-error: #ff0000;
   --color-button-confirm: #007bff;
   --color-button-confirm-hover: #0056b3;
   --color-button-confirm-text: #ffffff;
@@ -47,6 +52,9 @@
   --color-button-cancel: #bdc3c7;
   --color-button-cancel-hover: #c0c0c0;
   --color-button-cancel-text: #000000;
+  --color-list-bg: #ffffff;
+  --color-list-label: #555;
+  --color-list-value: #111;
 }
 
 :root[themeColor="dark_gray"] {
@@ -86,9 +94,14 @@
   --color-dialog-bg: #ffffff;
   --color-dialog-text: #000000;
 
+  /* プロフィール */
+  --color-message-profile-bg: #eaeaea;
+  --color-message-profile-text: #1a1a1a;
+
   /* 共通 */
   --color-bg: #ffffff;
   --color-text: #000000;
+  --color-text-error: #ff0000;
   --color-button-confirm: #2a2a2a;
   --color-button-confirm-hover: #1a1a1a;
   --color-button-confirm-text: #ffffff;
@@ -98,6 +111,15 @@
   --color-button-cancel: #bdc3c7;
   --color-button-cancel-hover: #c0c0c0;
   --color-button-cancel-text: #000000;
+  --color-list-bg: #ffffff;
+  --color-list-label: #555;
+  --color-list-value: #111;
+}
+
+/* 共通 */
+.body {
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 /* ヘッダー */
@@ -144,10 +166,6 @@ header {
 }
 
 /* ホーム */
-body {
-  background-color: var(--color-bg);
-}
-
 .company-title {
   color: var(--color-text);
 }
@@ -196,10 +214,6 @@ body {
 }
 
 /* メッセージ */
-.body {
-  background-color: var(--color-bg);
-}
-
 .department-title {
   color: var(--color-text);
 }
@@ -302,4 +316,45 @@ body {
 
 .confirm-btn.cancel:hover {
   background-color: var(--color-button-cancel-hover);
+}
+
+/* プロフィール */
+.main-content h2 {
+  background-color: var(--color-message-profile-bg);
+  color: var(--color-message-profile-text);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.profile-card {
+  background-color: var(--color-list-bg);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.profile-item {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.profile-label {
+  color: var(--color-list-label);
+}
+
+.value {
+  color: var(--color-list-value);
+}
+
+.profile-item input {
+  border: 1px solid #ccc;
+}
+
+.profile-btn {
+  background-color: var(--color-button-confirm);
+  color: var(--color-button-confirm-text);
+}
+
+.profile-btn:hover {
+  background-color: var(--color-button-confirm-hover);
+}
+
+.error-message {
+  color: var(--color-text-error);
 }

--- a/src/main/resources/static/css/profile.css
+++ b/src/main/resources/static/css/profile.css
@@ -2,31 +2,26 @@
   text-align: center;
   font-size: 1.5rem;
   font-weight: bold;
-  color: #007bff;
-  background-color: #f0f8ff;
   padding: 1rem;
   border-radius: 8px;
   margin: 1.5rem auto;
   max-width: 500px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
 .profile-card {
-  background-color: white;
   border-radius: 8px;
   padding: 1rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0;
 }
 
 .profile-item {
   display: flex;
   justify-content: space-between;
   padding: 0.5rem 1rem;
-  border-bottom: 1px solid #e0e0e0;
   white-space: nowrap;
+  margin-bottom: 0.75rem;
 }
 
 .profile-item:last-child {
@@ -35,15 +30,9 @@
 
 .profile-label {
   font-weight: bold;
-  color: #555;
-}
-
-.value {
-  color: #111;
 }
 
 .profile-item input {
-  border: 1px solid #ccc;
   border-radius: 5px;
   box-sizing: border-box;
 }
@@ -55,8 +44,6 @@
 }
 
 .profile-btn {
-  background-color: #007bff;
-  color: white;
   padding: 0.6rem 1.2rem;
   border: none;
   border-radius: 6px;
@@ -68,7 +55,6 @@
 }
 
 .profile-btn:hover {
-  background-color: #0056b3;
   transform: translateY(-2px);
 }
 
@@ -77,9 +63,49 @@
 }
 
 .error-message {
-  color: red;
   font-size: 0.9em;
-  margin-top: 4px;
+  margin: -0.75rem 0 4px;
   display: block;
   text-align: right;
+}
+
+/* 以下のデフォルトカラーは色設定変更完了後に削除する */
+.main-content h2 {
+  background-color: #f0f8ff;
+  color: #007bff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.profile-card {
+  background-color: white;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.profile-item {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.profile-label {
+  color: #555;
+}
+
+.value {
+  color: #111;
+}
+
+.profile-item input {
+  border: 1px solid #ccc;
+}
+
+.profile-btn {
+  background-color: #007bff;
+  color: white;
+}
+
+.profile-btn:hover {
+  background-color: #0056b3;
+}
+
+.error-message {
+  color: red;
 }

--- a/src/main/resources/templates/profile-edit-done.html
+++ b/src/main/resources/templates/profile-edit-done.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:attr="themeColor=${themeColor}">
   <head>
     <meta charset="UTF-8" />
     <title>Sharing Service Site</title>
     <link rel="stylesheet" th:href="@{/css/header.css}" />
     <link rel="stylesheet" th:href="@{/css/sidebar.css}" />
     <link rel="stylesheet" th:href="@{/css/profile.css}" />
+    <link rel="stylesheet" th:href="@{/css/color.css}" />
   </head>
   <body>
     <div th:replace="fragments/header :: header(${fullName})"></div>

--- a/src/main/resources/templates/profile-edit.html
+++ b/src/main/resources/templates/profile-edit.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:attr="themeColor=${themeColor}">
   <head>
     <meta charset="UTF-8" />
     <title>Sharing Service Site</title>
     <link rel="stylesheet" th:href="@{/css/header.css}" />
     <link rel="stylesheet" th:href="@{/css/sidebar.css}" />
     <link rel="stylesheet" th:href="@{/css/profile.css}" />
+    <link rel="stylesheet" th:href="@{/css/color.css}" />
   </head>
   <body>
     <div th:replace="fragments/header :: header(${fullName})"></div>

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:attr="themeColor=${themeColor}">
   <head>
     <meta charset="UTF-8" />
     <title>Sharing Service Site</title>
     <link rel="stylesheet" th:href="@{/css/header.css}" />
     <link rel="stylesheet" th:href="@{/css/sidebar.css}" />
     <link rel="stylesheet" th:href="@{/css/profile.css}" />
+    <link rel="stylesheet" th:href="@{/css/color.css}" />
   </head>
   <body>
     <div th:replace="fragments/header :: header(${fullName})"></div>


### PR DESCRIPTION
# 概要
テーマカラー設定をプロフィール画面に適応する

# 範囲
## やったこと
* 編集や完了画面を含むプロフィールページ関連の色設定を変更可能にした
* color.cssに、背景やテキストなどの共通の要素をまとめて変更可能な`.body{}`を追加した
* パスワードの変更画面で各項目の間のインライン空白を制御するため、gapをmarginで制御することでエラーメッセージの可読性を向上させた

## やっていないこと
* body要素に対してまとめて変更可能にしたが、正常に動作しないものが多いため要修正
* ダークグレーの背景を黒、テキストを白として変更したときに**正常に反映されない**ため修正が必要

# 動作確認
以下の実装と同様 #58 #59 

↓色変更前(ネイビーブルー)
<img width="1914" height="870" alt="image" src="https://github.com/user-attachments/assets/d1731b42-d1c7-4c20-a159-67f5828d711a" />
<img width="1913" height="871" alt="image" src="https://github.com/user-attachments/assets/8071cb05-210b-4a36-b1d5-ce295d81028d" />
<img width="1914" height="458" alt="image" src="https://github.com/user-attachments/assets/29aa4c4c-bb2d-4a0d-8b71-54d097bcdb97" />

↓色変更後 (ダークグレー)
<img width="1915" height="871" alt="image" src="https://github.com/user-attachments/assets/095be81f-5c09-4483-a6ab-a9ba591576d0" />
<img width="1914" height="873" alt="image" src="https://github.com/user-attachments/assets/8fd7df1b-2a06-40f8-a9e8-5002bd20fc80" />
<img width="1916" height="457" alt="image" src="https://github.com/user-attachments/assets/237b8492-6e13-479a-b651-10f2a71f773c" />

Issue: #57