### PR TITLE
設定画面の色設定実装

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/SettingsController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/SettingsController.java
@@ -32,6 +32,9 @@ public class SettingsController {
     model.addAttribute("fullName", userDetails.getFullName());
     Settings settings = settingsService.getSettingsByUserId(userDetails.getUserId());
     model.addAttribute("settings", settings);
+
+    String themeColor = settingsService.getThemeColorByUserId(userDetails.getUserId());
+    model.addAttribute("themeColor", themeColor);
     return "/settings";
   }
 
@@ -49,6 +52,9 @@ public class SettingsController {
     model.addAttribute("fullName", userDetails.getFullName());
     List<User> users = userDetailsService.getUsersByCompanyId(userDetails.getCompany().getCompanyId());
     model.addAttribute("users", users);
+
+    String themeColor = settingsService.getThemeColorByUserId(userDetails.getUserId());
+    model.addAttribute("themeColor", themeColor);
     return "/settings-user";
   }
 

--- a/src/main/resources/static/css/color.css
+++ b/src/main/resources/static/css/color.css
@@ -39,6 +39,10 @@
   --color-message-profile-bg: #f0f8ff;
   --color-message-profile-text: #007bff;
 
+  /* 設定 */
+  --color-toast-bg: #fff;
+  --color-toast-text: #333;
+
   /* 共通 */
   --color-bg: #ffffff;
   --color-text: #000000;
@@ -53,6 +57,8 @@
   --color-button-cancel-hover: #c0c0c0;
   --color-button-cancel-text: #000000;
   --color-list-bg: #ffffff;
+  --color-list-text: #000000;
+  --color-list-header: #f0f0f0;
   --color-list-label: #555;
   --color-list-value: #111;
 }
@@ -98,6 +104,10 @@
   --color-message-profile-bg: #eaeaea;
   --color-message-profile-text: #1a1a1a;
 
+  /* 設定 */
+  --color-toast-bg: #333;
+  --color-toast-text: #fff;
+
   /* 共通 */
   --color-bg: #ffffff;
   --color-text: #000000;
@@ -112,6 +122,8 @@
   --color-button-cancel-hover: #c0c0c0;
   --color-button-cancel-text: #000000;
   --color-list-bg: #ffffff;
+  --color-list-text: #000000;
+  --color-list-header: #f0f0f0;
   --color-list-label: #555;
   --color-list-value: #111;
 }
@@ -357,4 +369,60 @@ header {
 
 .error-message {
   color: var(--color-text-error);
+}
+
+/* 設定 */
+.settings-card {
+  background-color: var(--color-list-bg);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.settings-item {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.settings-label {
+  color: var(--color-list-label);
+}
+
+.value {
+  color: var(--color-list-value);
+}
+
+.settings-btn {
+  background-color: var(--color-button-confirm);
+  color: var(--color-button-confirm-text);
+}
+
+.settings-btn:hover {
+  background-color: var(--color-button-confirm-hover);
+}
+
+.user-header {
+  background-color: var(--color-list-header);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.user-row {
+  background-color: var(--color-list-bg);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.role-select {
+  border: 1px solid #ccc;
+}
+
+.save-role-btn {
+  background-color: var(--color-button-confirm);
+  color: var(--color-button-confirm-text);
+}
+
+.save-role-btn:hover {
+  background-color: var(--color-button-confirm-hover);
+}
+
+.toast {
+  background-color: var(--color-toast-bg);
+  color: var(--color-toast-text);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }

--- a/src/main/resources/static/css/settings.css
+++ b/src/main/resources/static/css/settings.css
@@ -1,8 +1,6 @@
 .settings-card {
-  background-color: white;
   border-radius: 8px;
   padding: 1rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -12,7 +10,6 @@
   display: flex;
   justify-content: space-between;
   padding: 0.5rem 1rem;
-  border-bottom: 1px solid #e0e0e0;
   white-space: nowrap;
 }
 
@@ -22,11 +19,6 @@
 
 .settings-label {
   font-weight: bold;
-  color: #555;
-}
-
-.value {
-  color: #111;
 }
 
 .settings-actions {
@@ -36,8 +28,6 @@
 }
 
 .settings-btn {
-  background-color: #007bff;
-  color: white;
   padding: 0.6rem 1.2rem;
   border: none;
   border-radius: 6px;
@@ -49,7 +39,6 @@
 }
 
 .settings-btn:hover {
-  background-color: #0056b3;
   transform: translateY(-2px);
 }
 
@@ -68,10 +57,8 @@
   display: grid;
   grid-template-columns: 1.5fr 1fr 2fr 1.5fr;
   font-weight: bold;
-  background-color: #f0f0f0;
   padding: 10px;
   border-radius: 6px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   white-space: nowrap;
 }
 
@@ -79,10 +66,8 @@
   display: grid;
   grid-template-columns: 1.5fr 1fr 2fr 1.5fr;
   align-items: center;
-  background-color: white;
   padding: 10px;
   border-radius: 6px;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
   transition: background-color 0.2s ease;
   white-space: nowrap;
 }
@@ -95,12 +80,9 @@
   padding: 4px;
   margin-right: 5px;
   border-radius: 4px;
-  border: 1px solid #ccc;
 }
 
 .save-role-btn {
-  background-color: #007bff;
-  color: white;
   border: none;
   border-radius: 4px;
   padding: 6px 10px;
@@ -109,19 +91,12 @@
   transition: background-color 0.2s ease;
 }
 
-.save-role-btn:hover {
-  background-color: #0056b3;
-}
-
 .toast {
   position: fixed;
   bottom: 20px;
   right: 20px;
-  background-color: #333;
-  color: #fff;
   padding: 12px 20px;
   border-radius: 6px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   opacity: 0;
   transform: translateY(20px);
   transition: opacity 0.5s, transform 0.5s;
@@ -131,4 +106,60 @@
 .toast.show {
   opacity: 1;
   transform: translateY(0);
+}
+
+/* 以下のデフォルトカラーは色設定変更完了後に削除する */
+.settings-card {
+  background-color: white;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.settings-item {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.settings-label {
+  color: #555;
+}
+
+.value {
+  color: #111;
+}
+
+.settings-btn {
+  background-color: #007bff;
+  color: white;
+}
+
+.settings-btn:hover {
+  background-color: #0056b3;
+}
+
+.user-header {
+  background-color: #f0f0f0;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.user-row {
+  background-color: white;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.role-select {
+  border: 1px solid #ccc;
+}
+
+.save-role-btn {
+  background-color: #007bff;
+  color: white;
+}
+
+.save-role-btn:hover {
+  background-color: #0056b3;
+}
+
+.toast {
+  background-color: #333;
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }

--- a/src/main/resources/templates/settings-user.html
+++ b/src/main/resources/templates/settings-user.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:attr="themeColor=${themeColor}">
   <head>
     <meta charset="UTF-8" />
     <title>Sharing Service Site</title>
     <link rel="stylesheet" th:href="@{/css/header.css}" />
     <link rel="stylesheet" th:href="@{/css/sidebar.css}" />
     <link rel="stylesheet" th:href="@{/css/settings.css}" />
+    <link rel="stylesheet" th:href="@{/css/color.css}" />
   </head>
   <body>
     <div th:replace="fragments/header :: header(${fullName})"></div>

--- a/src/main/resources/templates/settings.html
+++ b/src/main/resources/templates/settings.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:attr="themeColor=${themeColor}">
   <head>
     <meta charset="UTF-8" />
     <title>Sharing Service Site</title>
     <link rel="stylesheet" th:href="@{/css/header.css}" />
     <link rel="stylesheet" th:href="@{/css/sidebar.css}" />
     <link rel="stylesheet" th:href="@{/css/settings.css}" />
+    <link rel="stylesheet" th:href="@{/css/color.css}" />
   </head>
   <body>
     <div th:replace="fragments/header :: header(${fullName})"></div>


### PR DESCRIPTION
# 概要
設定画面のテーマカラー設定を実装する

# 範囲
## やったこと
設定画面の色設定

## やっていないこと
ボタンだけでなくリストなどのコンポーネントの共通化

# 動作確認
以下の実装と同様 #58 #59 #60

↓色変更前(ネイビーブルー)
<img width="1914" height="869" alt="image" src="https://github.com/user-attachments/assets/241868ab-bf13-450f-8bd6-0bb1ea083468" />
<img width="1918" height="514" alt="image" src="https://github.com/user-attachments/assets/1be81521-9dd6-4105-88d1-dc674c3b96c1" />

↓色変更後 (ダークグレー)
<img width="1915" height="868" alt="image" src="https://github.com/user-attachments/assets/8e322bda-2a74-40ec-b0e4-953225b0ab03" />
<img width="1917" height="519" alt="image" src="https://github.com/user-attachments/assets/362f9662-2b81-428c-b9f6-143ae180d88f" />

Issue: #57