### PR TITLE
エラーページの色設定実装

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/CustomErrorController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/CustomErrorController.java
@@ -7,11 +7,18 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.example.sharing_service_site.service.CustomUserDetails;
+import com.example.sharing_service_site.service.SettingsService;
 
 import jakarta.servlet.http.HttpServletRequest;
 
 @Controller
 public class CustomErrorController implements ErrorController {
+
+  private final SettingsService settingsService;
+
+  public CustomErrorController(SettingsService settingsService) {
+    this.settingsService = settingsService;
+  }
 
   @RequestMapping("/error")
   public String handleError(HttpServletRequest request,
@@ -23,6 +30,9 @@ public class CustomErrorController implements ErrorController {
     if (userDetails != null) {
       model.addAttribute("fullName", userDetails.getFullName());
     }
+
+    String themeColor = settingsService.getThemeColorByUserId(userDetails.getUserId());
+    model.addAttribute("themeColor", themeColor);
     return "error";
   }
 }

--- a/src/main/resources/static/css/color.css
+++ b/src/main/resources/static/css/color.css
@@ -43,6 +43,10 @@
   --color-toast-bg: #fff;
   --color-toast-text: #333;
 
+  /* エラーページ */
+  --color-text-error-title: #333;
+  --color-text-error-subtitle: #666;
+
   /* 共通 */
   --color-bg: #ffffff;
   --color-text: #000000;
@@ -107,6 +111,10 @@
   /* 設定 */
   --color-toast-bg: #333;
   --color-toast-text: #fff;
+
+  /* エラーページ */
+  --color-text-error-title: #333;
+  --color-text-error-subtitle: #666;
 
   /* 共通 */
   --color-bg: #ffffff;
@@ -425,4 +433,26 @@ header {
   background-color: var(--color-toast-bg);
   color: var(--color-toast-text);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+/* エラーページ */
+.error-status {
+  color: var(--color-header-bg);
+}
+
+.error-title {
+  color: var(--color-text-error-title);
+}
+
+.error-subtitle {
+  color: var(--color-text-error-subtitle);
+}
+
+.home-btn {
+  background-color: var(--color-button-confirm);
+  color: var(--color-button-confirm-text);
+}
+
+.home-btn:hover {
+  background-color: var(--color-button-confirm-hover);
 }

--- a/src/main/resources/static/css/error.css
+++ b/src/main/resources/static/css/error.css
@@ -20,19 +20,16 @@ body {
 .error-status {
   font-size: 6rem;
   font-weight: bold;
-  color: #001f4d;
   margin: 0;
 }
 
 .error-title {
   font-size: 1.5rem;
-  color: #333;
   margin: 0;
 }
 
 .error-subtitle {
   font-size: 1rem;
-  color: #666;
   max-width: 500px;
   margin: 0;
   line-height: 1.5;
@@ -42,11 +39,27 @@ body {
   display: inline-block;
   margin-top: 16px;
   padding: 10px 20px;
-  background-color: #007bff;
-  color: white;
   border-radius: 6px;
   font-weight: bold;
   transition: background-color 0.3s ease;
+}
+
+/* 以下のデフォルトカラーは色設定変更完了後に削除する */
+.error-status {
+  color: #001f4d;
+}
+
+.error-title {
+  color: #333;
+}
+
+.error-subtitle {
+  color: #666;
+}
+
+.home-btn {
+  background-color: #007bff;
+  color: white;
 }
 
 .home-btn:hover {

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,16 +1,17 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:attr="themeColor=${themeColor}">
   <head>
     <meta charset="UTF-8" />
     <title>Sharing Service Site</title>
     <link rel="stylesheet" th:href="@{/css/header.css}" />
     <link rel="stylesheet" th:href="@{/css/error.css}" />
+    <link rel="stylesheet" th:href="@{/css/color.css}" />
   </head>
   <body>
     <div th:replace="fragments/header :: header(${fullName})"></div>
 
     <div class="error-container">
-      <h1 class="error-status" th:text="${status}">404</h1>
+      <h1 class="error-status" th:text="${status}">エラーコード</h1>
 
       <h2 class="error-title" th:switch="${status}">
         <span th:case="404">ページが見つかりませんでした。</span>


### PR DESCRIPTION
# 概要
エラーページのテーマカラー設定を実装する

# 範囲
## やったこと
エラーページの色設定

## やっていないこと
実装完了後のデフォルトカラー設定のCSSの削除
→header, sidebar, home, message, profile, settings, errorの7ファイル

# 動作確認
以下の実装と同様 #58 #59 #60 #61

↓色変更前(ネイビーブルー)
<img width="1918" height="874" alt="image" src="https://github.com/user-attachments/assets/a50e40ad-8deb-4627-807c-3179e6a4a37a" />

↓色変更後 (ダークグレー)
<img width="1916" height="870" alt="image" src="https://github.com/user-attachments/assets/48fbd279-e8d1-4096-993f-ac6f6686d4b6" />

Issue: #57