### PR TITLE
メッセージページの認可処理を強化

### DIFF
--- a/src/main/java/com/example/sharing_service_site/controller/MessageController.java
+++ b/src/main/java/com/example/sharing_service_site/controller/MessageController.java
@@ -50,7 +50,7 @@ public class MessageController {
     model.addAttribute("user", user);
 
     String departmentName = departmentService.getDepartmentNameById(departmentId);
-    List<Message> messages = messageService.getMessagesByDepartmentId(departmentId);
+    List<Message> messages = messageService.getMessagesByDepartmentId(userDetails.getCompany().getCompanyId(), departmentId);
     model.addAttribute("selectedDepartmentName", departmentName);
     model.addAttribute("messages", messages);
 
@@ -69,7 +69,7 @@ public class MessageController {
     model.addAttribute("roleName", userDetails.getRoleName());
 
     String departmentName = departmentService.getDepartmentNameById(departmentId);
-    List<Message> messages = messageService.getMessagesByDepartmentId(departmentId);
+    List<Message> messages = messageService.getMessagesByDepartmentId(userDetails.getCompany().getCompanyId(), departmentId);
     model.addAttribute("selectedDepartmentName", departmentName);
     model.addAttribute("messages", messages);
 

--- a/src/main/java/com/example/sharing_service_site/entity/Department.java
+++ b/src/main/java/com/example/sharing_service_site/entity/Department.java
@@ -42,6 +42,7 @@ public class Department {
 
   public Long getDepartmentId() { return departmentId; }
   public String getDepartmentName() { return departmentName; }
+  public Long getCompanyId() { return company.getCompanyId(); } // 直接取得は理にかなっていないので削除したいが以下のメソッドを利用できないので使用
   // public Company getCompany() { return company; } // 追加すると部署が適切に表示されない
   public Department getParent() { return parent; }
   // public List<Department> getChildren() { return children; } // 追加すると部署が適切に表示されない

--- a/src/main/java/com/example/sharing_service_site/service/DepartmentService.java
+++ b/src/main/java/com/example/sharing_service_site/service/DepartmentService.java
@@ -55,4 +55,17 @@ public class DepartmentService {
         .map(Department::getDepartmentName)
         .orElse(null);
   }
+
+  /**
+   * 部署IDを指定して、その部署の会社IDを取得する
+   * 
+   * @param departmentId 部署ID
+   * @return 会社ID（部署が見つからない場合はnullを返す）
+   */
+  public Long getCompanyIdById(Long departmentId) {
+    return departmentRepository.findById(departmentId)
+        .map(Department::getCompanyId) // 以下のように取得したいがDepartmentエンティティにgetCompany()を追加すると部署が適切に表示されないためgetCompanyId()で対応
+        // .map(dept -> dept.getCompany().getCompanyId())
+        .orElse(null);
+  }
 }

--- a/src/main/java/com/example/sharing_service_site/service/MessageService.java
+++ b/src/main/java/com/example/sharing_service_site/service/MessageService.java
@@ -1,8 +1,10 @@
 package com.example.sharing_service_site.service;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import com.example.sharing_service_site.entity.Department;
@@ -19,13 +21,22 @@ public class MessageService {
   @Autowired
   private DepartmentRepository departmentRepository;
 
+  @Autowired
+  private DepartmentService departmentService;
+
   /**
    * 部署IDを基にメッセージを取得する
+   * ----------companyIdが一致しているかのチェックを追加----------
    * 
    * @param departmentId 部署ID
    * @return 該当するメッセージ一覧
    */
-  public List<Message> getMessagesByDepartmentId(Long departmentId) {
+  public List<Message> getMessagesByDepartmentId(Long userCompanyId, Long departmentId) {
+    Long departmentCompanyId = departmentService.getCompanyIdById(departmentId);
+
+    if (!Objects.equals(userCompanyId, departmentCompanyId)) {
+        throw new AccessDeniedException("Access denied to this department");
+    }
     return messageRepository.findByDepartmentDepartmentIdOrderByCreatedAtAsc(departmentId);
   }
 

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -14,6 +14,7 @@
       <h1 class="error-status" th:text="${status}">エラーコード</h1>
 
       <h2 class="error-title" th:switch="${status}">
+        <span th:case="403">アクセスが拒否されました。</span>
         <span th:case="404">ページが見つかりませんでした。</span>
         <span th:case="500">サーバーエラーが発生しました。</span>
         <span th:case="*">エラーが発生しました。</span>


### PR DESCRIPTION
# 概要
クエリパラメータで認可のないページを開ける問題を修正

# 範囲
## やったこと
* クエリパラメータで「?departmentId=」とPOSTされても問題ないように、messageServiceでユーザーの会社とページの会社が一致していることを確認してからページを表示する
* アクセスが許可されなかったときは403エラーのページを表示する
* DepartmentServiceで入力されたdepartmentIdからcompanyIdを取得する方法として、Departmentエンティティに直接メソッドを作成した(やっていないこと参照)

## やっていないこと
* Departmentエンティティで単純なgetCompany()メソッドを定義すると部署が適切に表示されないため作成していない
* 上記に伴い、DepartmentServiceのgetCompanyIdByIdで.map(dept -> dept.getCompany().getCompanyId())のようにCompanyIdを取得できない
* これらの問題の原因解明

# 動作確認
URLのようにクエリを入力
<img width="1918" height="285" alt="スクリーンショット 2025-11-15 201254" src="https://github.com/user-attachments/assets/4148b6ba-ea39-45fe-afa7-98e691ef2118" />

403エラーページが表示される
<img width="1915" height="789" alt="image" src="https://github.com/user-attachments/assets/b473b00a-e2f3-4a96-ac40-0ba00f2c7f20" />

Issue: #47 